### PR TITLE
Add chat message editing and deletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jdk-jammy@sha256:723151f3fc88ca2060153ee08ab8dbbea7983d6ed6f2622fe440acf178737c94 AS builder
+ARG BUILDPLATFORM
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy@sha256:723151f3fc88ca2060153ee08ab8dbbea7983d6ed6f2622fe440acf178737c94 AS builder
 WORKDIR /workspace
 
 COPY gradlew settings.gradle build.gradle ./

--- a/src/main/java/com/talkwithneighbors/controller/ChatController.java
+++ b/src/main/java/com/talkwithneighbors/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.talkwithneighbors.dto.ChatRoomDto;
 import com.talkwithneighbors.dto.CreateRoomRequest;
 import com.talkwithneighbors.dto.MessageDto;
 import com.talkwithneighbors.dto.UpdateChatRoomRequest;
+import com.talkwithneighbors.dto.UpdateChatMessageRequest;
 import com.talkwithneighbors.entity.ChatRoom;
 import com.talkwithneighbors.entity.ChatRoomType;
 import com.talkwithneighbors.entity.Message;
@@ -252,6 +253,28 @@ public class ChatController extends BaseController {
             mediaStorageService.deleteMedia(mediaStorageService.attachmentUrls(attachments));
             throw exception;
         }
+    }
+
+    @PatchMapping("/rooms/{roomId}/messages/{messageId}")
+    public ResponseEntity<MessageDto> updateMessage(
+            @PathVariable(name = "roomId") String roomId,
+            @PathVariable(name = "messageId") String messageId,
+            @RequestBody UpdateChatMessageRequest updateRequest,
+            HttpServletRequest request
+    ) {
+        User user = getCurrentUser(request);
+        return ResponseEntity.ok(chatService.updateMessage(
+                roomId, messageId, user.getId(), updateRequest.content()));
+    }
+
+    @DeleteMapping("/rooms/{roomId}/messages/{messageId}")
+    public ResponseEntity<MessageDto> deleteMessage(
+            @PathVariable(name = "roomId") String roomId,
+            @PathVariable(name = "messageId") String messageId,
+            HttpServletRequest request
+    ) {
+        User user = getCurrentUser(request);
+        return ResponseEntity.ok(chatService.deleteMessage(roomId, messageId, user.getId()));
     }
 
     @PostMapping("/rooms/{roomId}/messages/read")

--- a/src/main/java/com/talkwithneighbors/domain/event/ChatMessageChangedEvent.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/ChatMessageChangedEvent.java
@@ -1,0 +1,19 @@
+package com.talkwithneighbors.domain.event;
+
+import com.talkwithneighbors.dto.MessageDto;
+
+import java.util.List;
+
+/** Internal event delivered to every participant after an edit or deletion commits. */
+public record ChatMessageChangedEvent(
+        MessageDto message,
+        String roomId,
+        String lastMessage,
+        String lastMessageTime,
+        String lastSenderName,
+        List<Long> participantIds
+) {
+    public ChatMessageChangedEvent {
+        participantIds = List.copyOf(participantIds);
+    }
+}

--- a/src/main/java/com/talkwithneighbors/domain/event/ChatMessageChangedEventListener.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/ChatMessageChangedEventListener.java
@@ -1,0 +1,43 @@
+package com.talkwithneighbors.domain.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageChangedEventListener {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onMessageChanged(ChatMessageChangedEvent event) {
+        try {
+            String destination = "/queue/chat/room/" + event.roomId();
+            Map<String, Object> summary = new HashMap<>();
+            summary.put("chatRoomId", event.roomId());
+            summary.put("lastMessage", event.lastMessage());
+            summary.put("lastMessageTime", event.lastMessageTime());
+            summary.put("lastSenderName", event.lastSenderName());
+            Map<String, Object> roomUpdate = Map.of(
+                    "type", "CHAT_MESSAGE_CHANGED",
+                    "data", summary
+            );
+            event.participantIds().forEach(participantId -> {
+                messagingTemplate.convertAndSendToUser(
+                        participantId.toString(), destination, event.message());
+                messagingTemplate.convertAndSendToUser(
+                        participantId.toString(), "/queue/chat-updates", roomUpdate);
+            });
+        } catch (Exception exception) {
+            log.error("Failed to dispatch changed chat message. messageId={}, roomId={}",
+                    event.message().getId(), event.roomId(), exception);
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/dto/MessageDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/MessageDto.java
@@ -1,5 +1,6 @@
 package com.talkwithneighbors.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.talkwithneighbors.entity.Message;
 import com.talkwithneighbors.entity.Message.MessageType;
 
@@ -22,7 +23,10 @@ public class MessageDto {
     private String content;
     private String createdAt;
     private String updatedAt;
+    private String editedAt;
+    private String deletedAt;
     private MessageType type;
+    @JsonProperty("isDeleted")
     private boolean isDeleted;
     private Set<Long> readByUsers;
     private boolean readByCurrentUser;
@@ -43,10 +47,19 @@ public class MessageDto {
         if (message.getUpdatedAt() != null) {
             dto.setUpdatedAt(message.getUpdatedAt().format(formatter));
         }
+        if (message.getEditedAt() != null) {
+            dto.setEditedAt(message.getEditedAt().format(formatter));
+        }
+        if (message.getDeletedAt() != null) {
+            dto.setDeletedAt(message.getDeletedAt().format(formatter));
+        }
         dto.setType(message.getType());
         dto.setDeleted(message.isDeleted());
         List<com.talkwithneighbors.entity.MessageAttachment> attachments = message.getAttachments();
-        if (attachments == null || attachments.isEmpty()) {
+        if (message.isDeleted()) {
+            dto.setContent("");
+            dto.setAttachments(List.of());
+        } else if (attachments == null || attachments.isEmpty()) {
             dto.setAttachments(List.of());
         } else {
             dto.setAttachments(IntStream.range(0, attachments.size())

--- a/src/main/java/com/talkwithneighbors/dto/UpdateChatMessageRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/UpdateChatMessageRequest.java
@@ -1,0 +1,4 @@
+package com.talkwithneighbors.dto;
+
+public record UpdateChatMessageRequest(String content) {
+}

--- a/src/main/java/com/talkwithneighbors/entity/Message.java
+++ b/src/main/java/com/talkwithneighbors/entity/Message.java
@@ -78,11 +78,17 @@ public class Message {
      * 메시지 수정 시간
      */
     private LocalDateTime updatedAt;
+
+    @Column(name = "edited_at")
+    private LocalDateTime editedAt;
     
     /**
      * 메시지 삭제 상태
      */
     private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
     
     /**
      * 메시지 읽음 상태

--- a/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
@@ -26,6 +26,10 @@ public interface MessageRepository extends JpaRepository<Message, String> {
     @Query("SELECT m FROM Message m WHERE m.chatRoom.id = :roomId ORDER BY m.createdAt DESC")
     Page<Message> findByChatRoomIdOrderByCreatedAtDesc(@Param("roomId") String roomId, Pageable pageable);
 
+    @Query("SELECT m FROM Message m WHERE m.chatRoom.id = :roomId AND m.isDeleted = false ORDER BY m.createdAt DESC")
+    List<Message> findActiveByChatRoomIdOrderByCreatedAtDesc(
+            @Param("roomId") String roomId, Pageable pageable);
+
     @Query("SELECT DISTINCT m FROM Message m LEFT JOIN FETCH m.attachments WHERE m.chatRoom.id = :roomId")
     List<Message> findAllWithAttachmentsByChatRoomId(@Param("roomId") String roomId);
 

--- a/src/main/java/com/talkwithneighbors/service/ChatService.java
+++ b/src/main/java/com/talkwithneighbors/service/ChatService.java
@@ -27,6 +27,10 @@ public interface ChatService {
 
     MessageDto sendMessage(String roomId, Long senderId, String content, List<MessageAttachment> attachments);
 
+    MessageDto updateMessage(String roomId, String messageId, Long requesterId, String content);
+
+    MessageDto deleteMessage(String roomId, String messageId, Long requesterId);
+
     // 특정 채팅방의 메시지 목록 조회 (페이징 처리)
     Page<MessageDto> getMessagesByRoomId(String roomId, String userId, Pageable pageable);
 

--- a/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
@@ -5,6 +5,7 @@ import com.talkwithneighbors.dto.ChatRoomDto;
 import com.talkwithneighbors.dto.MessageDto;
 import com.talkwithneighbors.dto.UpdateChatRoomRequest;
 import com.talkwithneighbors.domain.event.ChatMessageCommittedEvent;
+import com.talkwithneighbors.domain.event.ChatMessageChangedEvent;
 import com.talkwithneighbors.domain.event.MediaFilesDeletedEvent;
 import com.talkwithneighbors.entity.ChatRoom;
 import com.talkwithneighbors.entity.ChatRoomType;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.context.ApplicationEventPublisher;
@@ -39,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -296,6 +299,133 @@ public class ChatServiceImpl implements ChatService {
                         room.getParticipants().stream().map(User::getId).toList()));
 
         return messageDto;
+    }
+
+    @Override
+    @Transactional
+    public MessageDto updateMessage(String roomId, String messageId, Long requesterId, String content) {
+        Message message = requireOwnedMessage(roomId, messageId, requesterId);
+        if (message.isDeleted()) {
+            throw new ChatException("삭제된 메시지는 수정할 수 없어.", HttpStatus.CONFLICT);
+        }
+        requireUserGeneratedMessage(message);
+
+        String normalizedContent = content == null ? "" : content.trim();
+        List<MessageAttachment> attachments = message.getAttachments() == null
+                ? List.of() : message.getAttachments();
+        if (normalizedContent.isEmpty() && attachments.isEmpty()) {
+            throw new ChatException("메시지 내용을 비워둘 수 없어.", HttpStatus.BAD_REQUEST);
+        }
+        if (normalizedContent.length() > 2000) {
+            throw new ChatException("메시지는 2,000자까지 수정할 수 있어.", HttpStatus.BAD_REQUEST);
+        }
+        if (normalizedContent.equals(message.getContent())) {
+            return MessageDto.fromEntity(message, requesterId);
+        }
+
+        LocalDateTime changedAt = LocalDateTime.now();
+        message.setContent(normalizedContent);
+        message.setType(resolveMessageType(normalizedContent, attachments));
+        message.setEditedAt(changedAt);
+        message.setUpdatedAt(changedAt);
+        Message savedMessage = messageRepository.save(message);
+        Message latestMessage = refreshRoomLastMessage(savedMessage.getChatRoom());
+
+        MessageDto messageDto = MessageDto.fromEntity(savedMessage, requesterId);
+        publishChangedMessage(messageDto, savedMessage.getChatRoom(), latestMessage);
+        return messageDto;
+    }
+
+    @Override
+    @Transactional
+    public MessageDto deleteMessage(String roomId, String messageId, Long requesterId) {
+        Message message = requireOwnedMessage(roomId, messageId, requesterId);
+        if (message.isDeleted()) {
+            return MessageDto.fromEntity(message, requesterId);
+        }
+        requireUserGeneratedMessage(message);
+
+        List<MessageAttachment> attachments = message.getAttachments() == null
+                ? List.of() : new ArrayList<>(message.getAttachments());
+        List<String> mediaUrls = attachments.stream()
+                .flatMap(attachment -> Stream.of(attachment.getUrl(), attachment.getThumbnailUrl()))
+                .filter(url -> url != null && !url.isBlank())
+                .distinct()
+                .toList();
+
+        LocalDateTime changedAt = LocalDateTime.now();
+        message.setContent("");
+        if (message.getAttachments() != null) {
+            message.getAttachments().clear();
+        }
+        message.setType(MessageType.SYSTEM);
+        message.setDeleted(true);
+        message.setDeletedAt(changedAt);
+        message.setUpdatedAt(changedAt);
+        Message savedMessage = messageRepository.save(message);
+        Message latestMessage = refreshRoomLastMessage(savedMessage.getChatRoom());
+
+        MessageDto messageDto = MessageDto.fromEntity(savedMessage, requesterId);
+        publishChangedMessage(messageDto, savedMessage.getChatRoom(), latestMessage);
+        if (!mediaUrls.isEmpty()) {
+            applicationEventPublisher.publishEvent(new MediaFilesDeletedEvent(mediaUrls));
+        }
+        return messageDto;
+    }
+
+    private Message requireOwnedMessage(String roomId, String messageId, Long requesterId) {
+        ChatRoom room = chatRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new ChatException("채팅방을 찾을 수 없어.", HttpStatus.NOT_FOUND));
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new ChatException("메시지를 찾을 수 없어.", HttpStatus.NOT_FOUND));
+        if (message.getChatRoom() == null || !roomId.equals(message.getChatRoom().getId())) {
+            throw new ChatException("메시지를 찾을 수 없어.", HttpStatus.NOT_FOUND);
+        }
+        boolean isParticipant = room.getParticipants().stream()
+                .anyMatch(participant -> participant.getId().equals(requesterId));
+        if (!isParticipant) {
+            throw new ChatException("이 채팅방의 메시지를 변경할 권한이 없어.", HttpStatus.FORBIDDEN);
+        }
+        if (message.getSender() == null || !message.getSender().getId().equals(requesterId)) {
+            throw new ChatException("내가 보낸 메시지만 수정하거나 삭제할 수 있어.", HttpStatus.FORBIDDEN);
+        }
+        return message;
+    }
+
+    private void requireUserGeneratedMessage(Message message) {
+        if (message.getType() != MessageType.TEXT
+                && message.getType() != MessageType.IMAGE
+                && message.getType() != MessageType.VIDEO
+                && message.getType() != MessageType.FILE) {
+            throw new ChatException("시스템 메시지는 수정하거나 삭제할 수 없어.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private Message refreshRoomLastMessage(ChatRoom room) {
+        List<Message> latestMessages = messageRepository.findActiveByChatRoomIdOrderByCreatedAtDesc(
+                room.getId(), PageRequest.of(0, 1));
+        Message latestMessage = null;
+        if (latestMessages == null || latestMessages.isEmpty()) {
+            room.setLastMessage(null);
+            room.setLastMessageTime(null);
+        } else {
+            latestMessage = latestMessages.get(0);
+            room.setLastMessage(lastMessagePreview(latestMessage));
+            room.setLastMessageTime(latestMessage.getCreatedAt());
+        }
+        chatRoomRepository.save(room);
+        return latestMessage;
+    }
+
+    private void publishChangedMessage(MessageDto messageDto, ChatRoom room, Message latestMessage) {
+        applicationEventPublisher.publishEvent(new ChatMessageChangedEvent(
+                messageDto,
+                room.getId(),
+                room.getLastMessage(),
+                room.getLastMessageTime() == null ? null : room.getLastMessageTime().toString(),
+                latestMessage == null || latestMessage.getSender() == null
+                        ? null : latestMessage.getSender().getUsername(),
+                room.getParticipants().stream().map(User::getId).toList()));
     }
 
     private MessageType resolveMessageType(String content, List<MessageAttachment> attachments) {

--- a/src/test/java/com/talkwithneighbors/controller/ChatControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/ChatControllerTest.java
@@ -5,6 +5,7 @@ import com.talkwithneighbors.dto.ChatMessageDto;
 import com.talkwithneighbors.dto.ChatRoomDto;
 import com.talkwithneighbors.dto.CreateRoomRequest;
 import com.talkwithneighbors.dto.MessageDto;
+import com.talkwithneighbors.dto.UpdateChatMessageRequest;
 import com.talkwithneighbors.entity.ChatRoomType;
 import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.exception.ChatException;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -203,6 +205,50 @@ class ChatControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value("msg-1"));
+    }
+
+    @Test
+    void updateMessageSuccess() throws Exception {
+        MessageDto response = new MessageDto();
+        response.setId("msg-1");
+        response.setContent("수정된 메시지");
+        when(chatService.updateMessage(eq("room-1"), eq("msg-1"), eq(1L), eq("수정된 메시지")))
+                .thenReturn(response);
+
+        mockMvc.perform(patch("/api/chat/rooms/{roomId}/messages/{messageId}", "room-1", "msg-1")
+                        .header(SESSION_HEADER, SESSION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new UpdateChatMessageRequest("수정된 메시지"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("msg-1"))
+                .andExpect(jsonPath("$.content").value("수정된 메시지"));
+    }
+
+    @Test
+    void deleteMessageSuccess() throws Exception {
+        MessageDto response = new MessageDto();
+        response.setId("msg-1");
+        response.setDeleted(true);
+        when(chatService.deleteMessage("room-1", "msg-1", 1L)).thenReturn(response);
+
+        mockMvc.perform(delete("/api/chat/rooms/{roomId}/messages/{messageId}", "room-1", "msg-1")
+                        .header(SESSION_HEADER, SESSION_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("msg-1"))
+                .andExpect(jsonPath("$.isDeleted").value(true));
+    }
+
+    @Test
+    void updateAnotherUsersMessageReturnsForbidden() throws Exception {
+        when(chatService.updateMessage(anyString(), anyString(), anyLong(), anyString()))
+                .thenThrow(new ChatException("내 메시지만 수정할 수 있어.", HttpStatus.FORBIDDEN));
+
+        mockMvc.perform(patch("/api/chat/rooms/{roomId}/messages/{messageId}", "room-1", "msg-2")
+                        .header(SESSION_HEADER, SESSION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateChatMessageRequest("수정"))))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/talkwithneighbors/domain/event/ChatMessageChangedEventListenerTest.java
+++ b/src/test/java/com/talkwithneighbors/domain/event/ChatMessageChangedEventListenerTest.java
@@ -1,0 +1,61 @@
+package com.talkwithneighbors.domain.event;
+
+import com.talkwithneighbors.dto.MessageDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageChangedEventListenerTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private ChatMessageChangedEventListener listener;
+
+    @Test
+    void sendsChangedMessageAndRoomSummaryToEveryParticipant() {
+        MessageDto message = new MessageDto();
+        message.setId("message-1");
+        message.setRoomId("room-1");
+        message.setContent("수정된 메시지");
+
+        ChatMessageChangedEvent event = new ChatMessageChangedEvent(
+                message,
+                "room-1",
+                "수정된 메시지",
+                "2026-07-13T12:34:56",
+                "코아",
+                List.of(11L, 22L)
+        );
+
+        listener.onMessageChanged(event);
+
+        Map<String, Object> roomUpdate = Map.of(
+                "type", "CHAT_MESSAGE_CHANGED",
+                "data", Map.of(
+                        "chatRoomId", "room-1",
+                        "lastMessage", "수정된 메시지",
+                        "lastMessageTime", "2026-07-13T12:34:56",
+                        "lastSenderName", "코아"
+                )
+        );
+        verify(messagingTemplate).convertAndSendToUser(
+                "11", "/queue/chat/room/room-1", message);
+        verify(messagingTemplate).convertAndSendToUser(
+                "22", "/queue/chat/room/room-1", message);
+        verify(messagingTemplate).convertAndSendToUser(
+                "11", "/queue/chat-updates", roomUpdate);
+        verify(messagingTemplate).convertAndSendToUser(
+                "22", "/queue/chat-updates", roomUpdate);
+    }
+}

--- a/src/test/java/com/talkwithneighbors/service/ChatServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/service/ChatServiceTest.java
@@ -18,6 +18,8 @@ import com.talkwithneighbors.repository.MessageRepository;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.repository.UserBlockRepository;
 import com.talkwithneighbors.domain.event.ChatMessageCommittedEvent;
+import com.talkwithneighbors.domain.event.ChatMessageChangedEvent;
+import com.talkwithneighbors.domain.event.MediaFilesDeletedEvent;
 import com.talkwithneighbors.service.impl.ChatServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -101,6 +104,9 @@ class ChatServiceTest {
         testMessage.setContent("Test message");
         testMessage.setSender(testUser);
         testMessage.setChatRoom(testChatRoom);
+        testMessage.setType(Message.MessageType.TEXT);
+        testMessage.setCreatedAt(LocalDateTime.now().minusMinutes(1));
+        testMessage.setUpdatedAt(testMessage.getCreatedAt());
 
         createRoomRequest = new CreateRoomRequest();
         createRoomRequest.setName("Test Room"); // 1:1 채팅 시 이 값은 무시될 수 있음
@@ -235,6 +241,87 @@ class ChatServiceTest {
         // when & then
         assertThrows(RuntimeException.class, () -> chatService.sendMessage(
             messageDto.getRoomId(), messageDto.getSenderId(), messageDto.getContent()));
+    }
+
+    @Test
+    void senderCanUpdateOwnMessageAndRoomPreview() {
+        when(chatRoomRepository.findByIdForUpdate(testChatRoom.getId())).thenReturn(Optional.of(testChatRoom));
+        when(messageRepository.findById(testMessage.getId())).thenReturn(Optional.of(testMessage));
+        when(messageRepository.save(testMessage)).thenReturn(testMessage);
+        when(messageRepository.findActiveByChatRoomIdOrderByCreatedAtDesc(eq(testChatRoom.getId()), any()))
+                .thenReturn(List.of(testMessage));
+
+        MessageDto result = chatService.updateMessage(
+                testChatRoom.getId(), testMessage.getId(), testUser.getId(), "  수정한 메시지  ");
+
+        assertEquals("수정한 메시지", result.getContent());
+        assertNotNull(result.getEditedAt());
+        assertEquals("수정한 메시지", testChatRoom.getLastMessage());
+        verify(applicationEventPublisher).publishEvent(any(ChatMessageChangedEvent.class));
+    }
+
+    @Test
+    void participantCannotUpdateAnotherUsersMessage() {
+        User otherParticipant = testChatRoom.getParticipants().stream()
+                .filter(user -> !user.getId().equals(testUser.getId()))
+                .findFirst()
+                .orElseThrow();
+        when(chatRoomRepository.findByIdForUpdate(testChatRoom.getId())).thenReturn(Optional.of(testChatRoom));
+        when(messageRepository.findById(testMessage.getId())).thenReturn(Optional.of(testMessage));
+
+        ChatException exception = assertThrows(ChatException.class, () -> chatService.updateMessage(
+                testChatRoom.getId(), testMessage.getId(), otherParticipant.getId(), "가로채기"));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatus());
+        verify(messageRepository, never()).save(any(Message.class));
+    }
+
+    @Test
+    void senderCanDeleteAttachmentMessageAndMediaIsCleanedAfterCommit() {
+        MessageAttachment attachment = new MessageAttachment(
+                "/uploads/chat/photo.webp",
+                "/uploads/chat/photo-thumbnail.webp",
+                ChatAttachmentType.IMAGE,
+                "image/webp",
+                "photo.jpg",
+                128L,
+                100,
+                100,
+                null
+        );
+        testMessage.setAttachments(new java.util.ArrayList<>(List.of(attachment)));
+        testMessage.setType(Message.MessageType.IMAGE);
+        when(chatRoomRepository.findByIdForUpdate(testChatRoom.getId())).thenReturn(Optional.of(testChatRoom));
+        when(messageRepository.findById(testMessage.getId())).thenReturn(Optional.of(testMessage));
+        when(messageRepository.save(testMessage)).thenReturn(testMessage);
+        when(messageRepository.findActiveByChatRoomIdOrderByCreatedAtDesc(eq(testChatRoom.getId()), any()))
+                .thenReturn(List.of());
+
+        MessageDto result = chatService.deleteMessage(
+                testChatRoom.getId(), testMessage.getId(), testUser.getId());
+
+        assertTrue(result.isDeleted());
+        assertEquals("", result.getContent());
+        assertTrue(result.getAttachments().isEmpty());
+        assertNotNull(result.getDeletedAt());
+        assertNull(testChatRoom.getLastMessage());
+        verify(applicationEventPublisher).publishEvent(any(ChatMessageChangedEvent.class));
+        verify(applicationEventPublisher).publishEvent(argThat((Object event) ->
+                event instanceof MediaFilesDeletedEvent deletedEvent
+                        && deletedEvent.mediaUrls().contains("/uploads/chat/photo.webp")
+                        && deletedEvent.mediaUrls().contains("/uploads/chat/photo-thumbnail.webp")));
+    }
+
+    @Test
+    void deletedMessageCannotBeUpdated() {
+        testMessage.setDeleted(true);
+        when(chatRoomRepository.findByIdForUpdate(testChatRoom.getId())).thenReturn(Optional.of(testChatRoom));
+        when(messageRepository.findById(testMessage.getId())).thenReturn(Optional.of(testMessage));
+
+        ChatException exception = assertThrows(ChatException.class, () -> chatService.updateMessage(
+                testChatRoom.getId(), testMessage.getId(), testUser.getId(), "되살리기"));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Added author-only REST endpoints for editing and deleting chat messages.
- Added distinct edit/delete timestamps and redacted soft-delete responses.
- Preserved attachments while editing and removed stored media after a deletion commits.
- Recomputed room previews after mutations and delivered message/room-summary updates to every participant after commit.
- Added controller, service, permission, media-cleanup, and realtime listener coverage.

## Why

Chat messages could be sent and read, but users could not correct or remove their own messages. Deleting an attachment message also needed to clean up persisted files without exposing stale content or room previews.

## Impact

Users can now edit or delete their own text and attachment messages. Other participants receive the change in realtime, deleted messages remain as safe placeholders, and room ordering/previews stay consistent.

## Validation

- Linux Docker backend build completed successfully.
- Full Gradle test suite passed in the Linux builder image.
- Docker Compose backend, frontend, MySQL, and Redis health checks passed.
- Two-user E2E verified owner edit success, non-owner edit 403, attachment cleanup (200 to 404), soft-delete history, and room preview restoration/clearing.