### PR TITLE
Add AWS k3s deployment and S3 media storage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+  - package-ecosystem: terraform
+    directory: "/infra/aws-ec2"
+    schedule:
+      interval: monthly
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,38 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+    services:
+      mysql:
+        image: mysql:8.4@sha256:c831a0f11348d402b43d77453e17d770be2eef356615a2823fe0f5a0d6c8b9af
+        env:
+          MYSQL_DATABASE: talk_with_neighbors
+          MYSQL_USER: twn
+          MYSQL_PASSWORD: ci-password
+          MYSQL_ROOT_PASSWORD: ci-root-password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -utwn -pci-password --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+      redis:
+        image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
           java-version: "17"
           cache: gradle
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - run: chmod +x gradlew
       - run: ./gradlew clean test bootJar --no-daemon
       - name: Validate production compose
@@ -34,7 +58,50 @@ jobs:
         run: docker compose -f compose.production.yml config --quiet
       - name: Build production container
         run: docker build -t talk-with-neighbors-backend:ci .
-      - uses: actions/upload-artifact@v7
+      - name: Scan container for fixable high-severity vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: talk-with-neighbors-backend:ci
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+      - name: Smoke-test container with MySQL and Redis
+        shell: bash
+        run: |
+          set -euo pipefail
+          trap 'docker rm -f talk-with-neighbors-backend-ci >/dev/null 2>&1 || true' EXIT
+          docker run --detach --name talk-with-neighbors-backend-ci --network host \
+            -e SPRING_PROFILES_ACTIVE=production \
+            -e 'SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/talk_with_neighbors?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
+            -e SPRING_DATASOURCE_USERNAME=twn \
+            -e SPRING_DATASOURCE_PASSWORD=ci-password \
+            -e SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE=1 \
+            -e SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE=5 \
+            -e SPRING_DATA_REDIS_HOST=127.0.0.1 \
+            -e SPRING_DATA_REDIS_PORT=6379 \
+            -e APP_SESSION_COOKIE_SECURE=false \
+            -e CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000 \
+            -e JAVA_OPTS='-Dfile.encoding=UTF-8 -Xms128m -Xmx512m -Duser.timezone=UTC' \
+            talk-with-neighbors-backend:ci
+
+          for _ in {1..90}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health/readiness | grep --quiet '"status":"UP"'; then
+              curl --fail --silent --show-error \
+                'http://127.0.0.1:8080/api/auth/check-duplicates?email=ci%40example.invalid&username=ci-smoke' >/dev/null
+              exit 0
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' talk-with-neighbors-backend-ci)" != "true" ]; then
+              docker logs talk-with-neighbors-backend-ci
+              exit 1
+            fi
+            sleep 2
+          done
+
+          docker logs talk-with-neighbors-backend-ci
+          exit 1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: backend-test-report

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -1,0 +1,164 @@
+name: Deploy EC2 k3s production
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_image:
+        description: "Backend digest, ghcr.io/gituserkhs/talk_with_neighbors_back@sha256:..."
+        required: true
+        type: string
+      frontend_image:
+        description: "Frontend digest, ghcr.io/gituserkhs/talk_with_neighbors_front@sha256:..."
+        required: true
+        type: string
+      public_origin:
+        description: "Optional HTTP origin; blank derives the current EC2 public IPv4 address"
+        required: false
+        type: string
+      start_if_stopped:
+        description: "Start the portfolio EC2 instance before deployment"
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: ec2-k3s-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy through AWS Systems Manager
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    environment: production
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      AWS_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      INSTANCE_ID: ${{ vars.EC2_INSTANCE_ID }}
+      DEPLOY_BUCKET: ${{ vars.DEPLOY_BUCKET }}
+      MEDIA_BUCKET: ${{ vars.MEDIA_BUCKET }}
+      BACKEND_IMAGE: ${{ inputs.backend_image }}
+      FRONTEND_IMAGE: ${{ inputs.frontend_image }}
+      PUBLIC_ORIGIN_INPUT: ${{ inputs.public_origin }}
+      START_IF_STOPPED: ${{ inputs.start_if_stopped }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Validate deployment inputs
+        env:
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$BACKEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_back@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid backend digest" >&2; exit 1; }
+          [[ "$FRONTEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_front@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid frontend digest" >&2; exit 1; }
+          [[ "$INSTANCE_ID" =~ ^i-[a-f0-9]{8,17}$ ]] || { echo "EC2_INSTANCE_ID is missing or invalid" >&2; exit 1; }
+          [[ -n "$AWS_ROLE_ARN" && -n "$DEPLOY_BUCKET" && -n "$MEDIA_BUCKET" ]] || { echo "AWS role and S3 bucket variables are required" >&2; exit 1; }
+          (( ${#MYSQL_PASSWORD} >= 16 )) || { echo "MYSQL_PASSWORD must contain at least 16 characters" >&2; exit 1; }
+          (( ${#MYSQL_ROOT_PASSWORD} >= 16 )) || { echo "MYSQL_ROOT_PASSWORD must contain at least 16 characters" >&2; exit 1; }
+          (( ${#JWT_SECRET} >= 32 )) || { echo "JWT_SECRET must contain at least 32 characters" >&2; exit 1; }
+          [[ -z "$GHCR_USERNAME" && -z "$GHCR_TOKEN" || -n "$GHCR_USERNAME" && -n "$GHCR_TOKEN" ]] || { echo "Set both GHCR credentials or neither" >&2; exit 1; }
+
+      - name: Configure short-lived AWS credentials
+        id: aws
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-ec2-k3s-${{ github.run_id }}
+
+      - name: Resolve and prepare the EC2 instance
+        id: instance
+        shell: bash
+        run: |
+          set -euo pipefail
+          state="$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name' --output text)"
+          if [[ "$state" == "stopped" && "$START_IF_STOPPED" == "true" ]]; then
+            aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null
+            aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+            state=running
+          elif [[ "$state" == "pending" ]]; then
+            aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+            state=running
+          fi
+          [[ "$state" == "running" ]] || { echo "EC2 is $state. Start it or select start_if_stopped." >&2; exit 1; }
+
+          public_ip="$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)"
+          [[ "$public_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "EC2 has no public IPv4 address" >&2; exit 1; }
+          public_origin="${PUBLIC_ORIGIN_INPUT:-http://${public_ip}}"
+          [[ "$public_origin" =~ ^http://[^/]+$ ]] || { echo "The base ingress supports an HTTP origin without a path only" >&2; exit 1; }
+
+          for _ in {1..60}; do
+            ping_status="$(aws ssm describe-instance-information --filters "Key=InstanceIds,Values=$INSTANCE_ID" --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null || true)"
+            [[ "$ping_status" == "Online" ]] && break
+            sleep 5
+          done
+          [[ "${ping_status:-}" == "Online" ]] || { echo "SSM agent did not become online within five minutes" >&2; exit 1; }
+          echo "public_origin=$public_origin" >> "$GITHUB_OUTPUT"
+
+      - name: Build the private deployment bundle
+        env:
+          PUBLIC_ORIGIN: ${{ steps.instance.outputs.public_origin }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        shell: bash
+        run: bash deploy/k8s/build-bundle.sh "$RUNNER_TEMP/deploy-bundle.tgz"
+
+      - name: Deploy through S3 and SSM
+        shell: bash
+        run: |
+          bash deploy/k8s/deploy-via-ssm.sh \
+            "$INSTANCE_ID" \
+            "$DEPLOY_BUCKET" \
+            "deployments/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/bundle.tgz" \
+            "$RUNNER_TEMP/deploy-bundle.tgz" \
+            "$BACKEND_IMAGE" \
+            "$FRONTEND_IMAGE" \
+            "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Run strict public smoke tests
+        env:
+          PUBLIC_ORIGIN: ${{ steps.instance.outputs.public_origin }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          health_status="$(curl --fail --show-error --silent --retry 12 --retry-all-errors --retry-delay 5 --output "$RUNNER_TEMP/healthz.txt" --write-out '%{http_code}' "$PUBLIC_ORIGIN/healthz")"
+          [[ "$health_status" == "200" ]] || { echo "healthz returned HTTP $health_status" >&2; exit 1; }
+          [[ "$(tr -d '\r\n' < "$RUNNER_TEMP/healthz.txt")" == "ok" ]] || { echo "healthz returned an unexpected body" >&2; exit 1; }
+          api_status="$(curl --fail --show-error --silent --retry 12 --retry-all-errors --retry-delay 5 --output "$RUNNER_TEMP/api-smoke.json" --write-out '%{http_code}' "$PUBLIC_ORIGIN/api/auth/check-duplicates?email=deploy-smoke%40example.invalid&username=deploy-smoke")"
+          [[ "$api_status" == "200" ]] || { echo "API smoke test returned HTTP $api_status" >&2; exit 1; }
+          jq -e 'type == "object" and ((.emailExists | type) == "boolean") and ((.usernameExists | type) == "boolean")' "$RUNNER_TEMP/api-smoke.json" >/dev/null
+
+      - name: Write deployment summary
+        env:
+          PUBLIC_ORIGIN: ${{ steps.instance.outputs.public_origin }}
+        shell: bash
+        run: |
+          {
+            echo "### EC2 k3s deployment succeeded"
+            printf -- "- URL: <%s>\n" "$PUBLIC_ORIGIN"
+            printf -- "- Backend: \`%s\`\n" "$BACKEND_IMAGE"
+            printf -- "- Frontend: \`%s\`\n" "$FRONTEND_IMAGE"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove runner plaintext files
+        if: always()
+        shell: bash
+        run: |
+          for path in "$RUNNER_TEMP/deploy-bundle.tgz" "$RUNNER_TEMP/healthz.txt" "$RUNNER_TEMP/api-smoke.json"; do
+            if [[ -f "$path" ]]; then
+              shred -u -- "$path" 2>/dev/null || rm -f -- "$path"
+            fi
+          done

--- a/.github/workflows/ec2-power.yml
+++ b/.github/workflows/ec2-power.yml
@@ -1,0 +1,91 @@
+name: Control portfolio EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Power action"
+        required: true
+        default: status
+        type: choice
+        options:
+          - status
+          - start
+          - stop
+
+concurrency:
+  group: ec2-k3s-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  control:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      AWS_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      INSTANCE_ID: ${{ vars.EC2_INSTANCE_ID }}
+    steps:
+      - name: Validate configuration
+        shell: bash
+        run: |
+          [[ "$INSTANCE_ID" =~ ^i-[a-f0-9]{8,17}$ ]] || { echo "EC2_INSTANCE_ID is missing or invalid" >&2; exit 1; }
+          [[ -n "$AWS_ROLE_ARN" ]] || { echo "AWS_DEPLOY_ROLE_ARN is required" >&2; exit 1; }
+
+      - name: Configure short-lived AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-ec2-power-${{ github.run_id }}
+
+      - name: Apply power action
+        id: power
+        env:
+          POWER_ACTION: ${{ inputs.action }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name' --output text)"
+          case "$POWER_ACTION" in
+            start)
+              if [[ "$current" == "stopped" ]]; then
+                aws ec2 start-instances --instance-ids "$INSTANCE_ID" >/dev/null
+                aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+              elif [[ "$current" != "running" ]]; then
+                echo "Cannot start an instance in state $current" >&2
+                exit 1
+              fi
+              ;;
+            stop)
+              if [[ "$current" == "running" ]]; then
+                aws ec2 stop-instances --instance-ids "$INSTANCE_ID" >/dev/null
+                aws ec2 wait instance-stopped --instance-ids "$INSTANCE_ID"
+              elif [[ "$current" != "stopped" ]]; then
+                echo "Cannot stop an instance in state $current" >&2
+                exit 1
+              fi
+              ;;
+            status) ;;
+            *) echo "Unsupported action: $POWER_ACTION" >&2; exit 1 ;;
+          esac
+
+          final="$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name' --output text)"
+          public_ip="$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)"
+          echo "state=$final" >> "$GITHUB_OUTPUT"
+          echo "public_ip=$public_ip" >> "$GITHUB_OUTPUT"
+
+      - name: Write power summary
+        shell: bash
+        run: |
+          echo "### Portfolio EC2" >> "$GITHUB_STEP_SUMMARY"
+          echo "- State: **${{ steps.power.outputs.state }}**" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.power.outputs.public_ip }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "- URL: <http://${{ steps.power.outputs.public_ip }}>" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -1,0 +1,91 @@
+name: Infrastructure CI
+
+on:
+  pull_request:
+    paths:
+      - "infra/**"
+      - "deploy/k8s/**"
+      - ".github/workflows/infra-ci.yml"
+      - ".github/workflows/deploy-k3s.yml"
+  push:
+    branches: [main]
+    paths:
+      - "infra/**"
+      - "deploy/k8s/**"
+      - ".github/workflows/infra-ci.yml"
+      - ".github/workflows/deploy-k3s.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: infrastructure-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: Terraform format and validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: infra/aws-ec2
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: 1.14.6
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false -input=false
+      - run: terraform validate -no-color
+      - run: terraform test -no-color
+
+  kubernetes:
+    name: Render and validate Kubernetes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
+        with:
+          version: v1.34.1
+      - name: Render kustomization
+        run: kubectl kustomize deploy/k8s/base > rendered-kubernetes.yaml
+      - name: Validate schemas
+        run: >-
+          docker run --rm
+          -v "${PWD}:/work"
+          ghcr.io/yannh/kubeconform:v0.7.0@sha256:85dbef6b4b312b99133decc9c6fc9495e9fc5f92293d4ff3b7e1b30f5611823c
+          -strict -summary
+          -kubernetes-version 1.34.0
+          /work/rendered-kubernetes.yaml
+          /work/deploy/k8s/runtime-config.example.yaml
+          /work/deploy/k8s/secrets.example.yaml
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rendered-kubernetes
+          path: rendered-kubernetes.yaml
+          if-no-files-found: error
+          retention-days: 7
+
+  workflows:
+    name: GitHub Actions lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Run ShellCheck on deployment scripts
+        run: >-
+          docker run --rm
+          -v "${PWD}:/repo"
+          koalaman/shellcheck:stable@sha256:bb596a0d169b85ddd81d8b6d3a2ff6d5baf5fca10b97f575ebc647c3dff62b3d
+          /repo/deploy/k8s/build-bundle.sh
+          /repo/deploy/k8s/deploy-via-ssm.sh
+          /repo/deploy/k8s/deploy-on-node.sh
+      - name: Run actionlint
+        run: >-
+          docker run --rm
+          -v "${PWD}:/repo"
+          -w /repo
+          rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -12,24 +12,99 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  publish:
+  quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    services:
+      mysql:
+        image: mysql:8.4@sha256:c831a0f11348d402b43d77453e17d770be2eef356615a2823fe0f5a0d6c8b9af
+        env:
+          MYSQL_DATABASE: talk_with_neighbors
+          MYSQL_USER: twn
+          MYSQL_PASSWORD: publish-ci-password
+          MYSQL_ROOT_PASSWORD: publish-ci-root-password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -utwn -ppublish-ci-password --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+      redis:
+        image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+      - run: chmod +x gradlew
+      - run: ./gradlew clean test bootJar --no-daemon
+      - name: Validate production compose
+        env:
+          MYSQL_PASSWORD: publish-ci-password
+          MYSQL_ROOT_PASSWORD: publish-ci-root-password
+          JWT_SECRET: publish-ci-only-secret-that-is-long-enough
+          PUBLIC_ORIGIN: https://example.invalid
+        run: docker compose -f compose.production.yml config --quiet
+
+  publish:
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+    services:
+      mysql:
+        image: mysql:8.4@sha256:c831a0f11348d402b43d77453e17d770be2eef356615a2823fe0f5a0d6c8b9af
+        env:
+          MYSQL_DATABASE: talk_with_neighbors
+          MYSQL_USER: twn
+          MYSQL_PASSWORD: publish-ci-password
+          MYSQL_ROOT_PASSWORD: publish-ci-root-password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -utwn -ppublish-ci-password --silent"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=30
+      redis:
+        image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Normalize image name
         id: image
         shell: bash
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
           images: ${{ steps.image.outputs.name }}
@@ -38,11 +113,81 @@ jobs:
             type=ref,event=tag
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-      - uses: docker/build-push-action@v6
+      - name: Build and push an isolated candidate
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.image.outputs.name }}:candidate-${{ github.run_id }}-${{ github.run_attempt }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+      - name: Scan the exact pushed digest
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+      - name: Smoke-test the exact pushed digest
+        env:
+          RELEASE_IMAGE: ${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trap 'docker rm -f talk-with-neighbors-backend-release >/dev/null 2>&1 || true' EXIT
+          docker run --detach --name talk-with-neighbors-backend-release --network host \
+            -e SPRING_PROFILES_ACTIVE=production \
+            -e 'SPRING_DATASOURCE_URL=jdbc:mysql://127.0.0.1:3306/talk_with_neighbors?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC' \
+            -e SPRING_DATASOURCE_USERNAME=twn \
+            -e SPRING_DATASOURCE_PASSWORD=publish-ci-password \
+            -e SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE=1 \
+            -e SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE=5 \
+            -e SPRING_DATA_REDIS_HOST=127.0.0.1 \
+            -e SPRING_DATA_REDIS_PORT=6379 \
+            -e APP_SESSION_COOKIE_SECURE=false \
+            -e CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000 \
+            -e JAVA_OPTS='-Dfile.encoding=UTF-8 -Xms128m -Xmx512m -Duser.timezone=UTC' \
+            "$RELEASE_IMAGE"
+
+          for _ in {1..90}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health/readiness | grep --quiet '"status":"UP"'; then
+              curl --fail --silent --show-error \
+                'http://127.0.0.1:8080/api/auth/check-duplicates?email=publish%40example.invalid&username=publish-smoke' >/dev/null
+              exit 0
+            fi
+            if [ "$(docker inspect --format '{{.State.Running}}' talk-with-neighbors-backend-release)" != "true" ]; then
+              docker logs talk-with-neighbors-backend-release
+              exit 1
+            fi
+            sleep 2
+          done
+
+          docker logs talk-with-neighbors-backend-release
+          exit 1
+      - name: Promote the verified digest to release tags
+        env:
+          RELEASE_IMAGE: ${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}
+          RELEASE_TAGS: ${{ steps.meta.outputs.tags }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_args=()
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] && tag_args+=(--tag "$tag")
+          done <<<"$RELEASE_TAGS"
+          (( ${#tag_args[@]} > 0 )) || { echo "No release tags were generated" >&2; exit 1; }
+          docker buildx imagetools create "${tag_args[@]}" "$RELEASE_IMAGE"
+      - name: Write immutable deployment reference
+        env:
+          RELEASE_IMAGE: ${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}
+        shell: bash
+        run: |
+          echo "### Verified backend image" >> "$GITHUB_STEP_SUMMARY"
+          printf "\`%s\`\n" "$RELEASE_IMAGE" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,16 @@ backend-dev*.log
 
 ### Local uploaded media ###
 /uploads/
+
+### Terraform ###
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*
+**/.terraform.tfstate.lock.info
+**/terraform.tfvars
+**/*.auto.tfvars
+**/crash.log
+**/crash.*.log
+**/tfplan
+**/*.tfplan
+!**/terraform.tfvars.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine AS builder
+FROM eclipse-temurin:17-jdk-jammy@sha256:723151f3fc88ca2060153ee08ab8dbbea7983d6ed6f2622fe440acf178737c94 AS builder
 WORKDIR /workspace
 
 COPY gradlew settings.gradle build.gradle ./
@@ -9,17 +9,20 @@ RUN ./gradlew dependencies --no-daemon
 COPY src src
 RUN ./gradlew bootJar -x test --no-daemon
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre-jammy@sha256:475d8e96b4b2bfe08999e5e854755c773af1581acdf959a4545d88f0696a2339
 WORKDIR /app
 
-RUN apk add --no-cache ffmpeg \
-    && addgroup -S spring && adduser -S spring -G spring \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system spring \
+    && useradd --system --gid spring --home-dir /app --shell /usr/sbin/nologin spring \
     && mkdir -p /app/uploads \
     && chown -R spring:spring /app/uploads
 COPY --from=builder /workspace/build/libs/*.jar app.jar
 USER spring:spring
 
 EXPOSE 8080
-ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
-HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=12 CMD wget -q -O /dev/null 'http://127.0.0.1:8080/api/auth/check-duplicates?email=health%40local&username=health' || exit 1
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ENV JAVA_OPTS="-Dfile.encoding=UTF-8 -XX:MaxRAMPercentage=75.0"
+HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=12 CMD wget -q -O /dev/null 'http://127.0.0.1:8080/actuator/health/liveness' || exit 1
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Spring Boot 3 기반의 이웃톡 백엔드야. 인증, 피드, 관심사 매칭
 
 프로필 사진, 피드 사진·동영상, 채팅 사진·동영상·문서는 `uploads_data` Docker 볼륨에 저장되므로 컨테이너를 다시 만들어도 유지돼. 이미지와 영상은 WebP·MP4로 최적화되고 썸네일도 같은 볼륨에 보관해. DB·Redis·업로드 데이터를 모두 지우려는 경우가 아니라면 `docker compose down -v`는 사용하지 마.
 
-현재 프로젝트는 로컬 전용으로 운영해. PR과 `main` 브랜치 푸시에서는 GitHub Actions가 테스트와 `bootJar` 생성을 수행하지만, 이미지 게시 워크플로는 수동 비활성화 상태야.
+로컬 개발은 계속 상위 폴더의 Docker Compose를 기본으로 사용해. PR과 `main` 브랜치에서는 GitHub Actions가 테스트, `bootJar`, 프로덕션 이미지, MySQL·Redis 연동 컨테이너 스모크 테스트를 검증해. `main`과 버전 태그의 이미지는 같은 품질 검증을 통과한 뒤 GHCR에 게시돼.
 
-CI는 애플리케이션 테스트뿐 아니라 실제 프로덕션 Docker 이미지 빌드도 검증해.
+선택형 AWS 포트폴리오 배포는 [EC2 + S3 + k3s 가이드](docs/deployment/aws-k3s.md)를 따라. Terraform과 SSM 배포 워크플로가 준비되어 있지만 비용이 발생하는 `terraform apply`는 자동 실행하지 않아.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.3'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.5.16'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.talkwithneighbors'
@@ -28,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.security:spring-security-messaging'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation platform('software.amazon.awssdk:bom:2.47.5')
+	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.session:spring-session-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'
@@ -47,6 +50,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 	systemProperty 'spring.profiles.active', 'test'
+	jvmArgs '-Dfile.encoding=UTF-8'
 }
 
 compileJava {

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -2,7 +2,7 @@ name: talk-with-neighbors
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4@sha256:c831a0f11348d402b43d77453e17d770be2eef356615a2823fe0f5a0d6c8b9af
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-talk_with_neighbors}
@@ -19,7 +19,7 @@ services:
       start_period: 20s
 
   redis:
-    image: redis:7.4-alpine
+    image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     restart: unless-stopped
     volumes:
       - redis_data:/data
@@ -33,19 +33,35 @@ services:
     image: ghcr.io/gituserkhs/talk_with_neighbors_back:${IMAGE_TAG:-latest}
     restart: unless-stopped
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-production}
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-talk_with_neighbors}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:-twn}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: ${DB_POOL_MIN_IDLE:-2}
+      SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: ${DB_POOL_MAX_SIZE:-10}
+      SPRING_JPA_SHOW_SQL: ${SPRING_JPA_SHOW_SQL:-false}
       SPRING_DATA_REDIS_HOST: redis
       SPRING_SESSION_STORE_TYPE: redis
       APP_REDIS_ENABLED: "true"
       JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET}
       CORS_ALLOWED_ORIGINS: ${PUBLIC_ORIGIN:?set PUBLIC_ORIGIN}
+      APP_SESSION_COOKIE_SECURE: ${APP_SESSION_COOKIE_SECURE:-false}
+      APP_MEDIA_STORAGE_DIRECTORY: /app/uploads
+      APP_MEDIA_MAX_CONCURRENT_PROCESSES: ${APP_MEDIA_MAX_CONCURRENT_PROCESSES:-1}
+      JAVA_OPTS: ${BACKEND_JAVA_OPTS:--Dfile.encoding=UTF-8 -XX:MaxRAMPercentage=70.0 -XX:InitialRAMPercentage=25.0 -XX:+UseG1GC}
+    volumes:
+      - media_data:/app/uploads
     depends_on:
       mysql:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/actuator/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 45s
 
   frontend:
     image: ghcr.io/gituserkhs/talk_with_neighbors_front:${IMAGE_TAG:-latest}
@@ -59,3 +75,4 @@ services:
 volumes:
   mysql_data:
   redis_data:
+  media_data:

--- a/deploy/k8s/base/backend.yaml
+++ b/deploy/k8s/base/backend.yaml
@@ -1,0 +1,178 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+spec:
+  selector:
+    app.kubernetes.io/name: backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+spec:
+  # In-memory STOMP and scheduled jobs still make one replica the safe limit.
+  # Durable media is stored in S3; /tmp is only an FFmpeg staging area.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  template:
+    metadata:
+      annotations:
+        talkwithneighbors.io/release: REPLACE_RELEASE_ID
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/component: api
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull
+      terminationGracePeriodSeconds: 300
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: backend
+          image: ghcr.io/gituserkhs/talk_with_neighbors_back@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: production
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:mysql://mysql:3306/talk_with_neighbors?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true
+            - name: SPRING_DATASOURCE_USERNAME
+              value: twn
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: mysql-password
+            - name: SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE
+              value: "1"
+            - name: SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE
+              value: "5"
+            - name: SPRING_DATA_REDIS_HOST
+              value: redis
+            - name: SPRING_DATA_REDIS_PORT
+              value: "6379"
+            - name: SPRING_SESSION_STORE_TYPE
+              value: redis
+            - name: APP_REDIS_ENABLED
+              value: "true"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret
+            - name: CORS_ALLOWED_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: public-origin
+            - name: CORS_ALLOWED_METHODS
+              value: GET,POST,PUT,PATCH,DELETE,OPTIONS
+            - name: APP_SESSION_COOKIE_SECURE
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: cookie-secure
+            - name: APP_MEDIA_STORAGE_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: media-storage-type
+            - name: APP_MEDIA_S3_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: media-s3-region
+            - name: APP_MEDIA_S3_BUCKET
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: media-s3-bucket
+            - name: APP_MEDIA_S3_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: runtime-config
+                  key: media-s3-prefix
+            - name: APP_MEDIA_STORAGE_DIRECTORY
+              value: /tmp/twn-media
+            - name: APP_MEDIA_MAX_CONCURRENT_PROCESSES
+              value: "1"
+            - name: SERVER_TOMCAT_THREADS_MAX
+              value: "50"
+            - name: SERVER_TOMCAT_THREADS_MIN_SPARE
+              value: "5"
+            - name: JAVA_OPTS
+              value: -Dfile.encoding=UTF-8 -Xms192m -Xmx448m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError -Duser.timezone=UTC
+            - name: TZ
+              value: UTC
+            - name: SERVER_FORWARD_HEADERS_STRATEGY
+              value: framework
+            - name: SERVER_SHUTDOWN
+              value: graceful
+            - name: SPRING_LIFECYCLE_TIMEOUT_PER_SHUTDOWN_PHASE
+              value: 240s
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            failureThreshold: 36
+            periodSeconds: 5
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: "1"
+              memory: 896Mi
+              ephemeral-storage: 2Gi
+          volumeMounts:
+            - name: temp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: temp
+          emptyDir:
+            sizeLimit: 2Gi

--- a/deploy/k8s/base/frontend.yaml
+++ b/deploy/k8s/base/frontend.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+spec:
+  selector:
+    app.kubernetes.io/name: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/component: web
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: frontend
+          image: ghcr.io/gituserkhs/talk_with_neighbors_front@sha256:0000000000000000000000000000000000000000000000000000000000000000
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/k8s/base/ingress.yaml
+++ b/deploy/k8s/base/ingress.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: application
+  labels:
+    app.kubernetes.io/name: application-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080
+          - path: /uploads
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080
+          - path: /ws
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: talk-with-neighbors
+resources:
+  - namespace.yaml
+  - mysql.yaml
+  - redis.yaml
+  - backend.yaml
+  - frontend.yaml
+  - ingress.yaml

--- a/deploy/k8s/base/mysql.yaml
+++ b/deploy/k8s/base/mysql.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+spec:
+  selector:
+    app.kubernetes.io/name: mysql
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: database
+    spec:
+      terminationGracePeriodSeconds: 120
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: mysql
+          image: mysql:8.4@sha256:c831a0f11348d402b43d77453e17d770be2eef356615a2823fe0f5a0d6c8b9af
+          imagePullPolicy: IfNotPresent
+          args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+            - --max-connections=30
+            - --innodb-buffer-pool-size=192M
+            - --performance-schema=OFF
+          ports:
+            - name: mysql
+              containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              value: talk_with_neighbors
+            - name: MYSQL_USER
+              value: twn
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: mysql-password
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: mysql-root-password
+            - name: TZ
+              value: UTC
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - mysqladmin ping -h 127.0.0.1 -u root -p"$MYSQL_ROOT_PASSWORD" --silent
+            failureThreshold: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - mysqladmin ping -h 127.0.0.1 -u root -p"$MYSQL_ROOT_PASSWORD" --silent
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - mysqladmin ping -h 127.0.0.1 -u root -p"$MYSQL_ROOT_PASSWORD" --silent
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 150m
+              memory: 384Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/k8s/base/namespace.yaml
+++ b/deploy/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: talk-with-neighbors
+  labels:
+    app.kubernetes.io/part-of: talk-with-neighbors

--- a/deploy/k8s/base/redis.yaml
+++ b/deploy/k8s/base/redis.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: cache
+    spec:
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: redis
+          image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+          imagePullPolicy: IfNotPresent
+          args:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --appendfsync
+            - everysec
+            - --maxmemory
+            - 128mb
+            - --maxmemory-policy
+            - noeviction
+          ports:
+            - name: redis
+              containerPort: 6379
+          startupProbe:
+            exec:
+              command: [redis-cli, ping]
+            failureThreshold: 20
+            periodSeconds: 3
+          readinessProbe:
+            exec:
+              command: [redis-cli, ping]
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command: [redis-cli, ping]
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 192Mi
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 1Gi

--- a/deploy/k8s/build-bundle.sh
+++ b/deploy/k8s/build-bundle.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly OUTPUT_ARCHIVE="${1:?output archive path is required}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PUBLIC_ORIGIN="${PUBLIC_ORIGIN:?PUBLIC_ORIGIN is required}"
+readonly AWS_REGION="${AWS_REGION:?AWS_REGION is required}"
+readonly MEDIA_BUCKET="${MEDIA_BUCKET:?MEDIA_BUCKET is required}"
+readonly MYSQL_PASSWORD="${MYSQL_PASSWORD:?MYSQL_PASSWORD is required}"
+readonly MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD is required}"
+readonly JWT_SECRET="${JWT_SECRET:?JWT_SECRET is required}"
+
+[[ "$PUBLIC_ORIGIN" =~ ^http://[^/]+$ ]] || { echo "Only an HTTP origin without a path is supported by the base ingress" >&2; exit 1; }
+[[ "$AWS_REGION" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]] || { echo "Invalid AWS region" >&2; exit 1; }
+[[ "$MEDIA_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || { echo "Invalid S3 bucket name" >&2; exit 1; }
+(( ${#MYSQL_PASSWORD} >= 16 )) || { echo "MYSQL_PASSWORD must contain at least 16 characters" >&2; exit 1; }
+(( ${#MYSQL_ROOT_PASSWORD} >= 16 )) || { echo "MYSQL_ROOT_PASSWORD must contain at least 16 characters" >&2; exit 1; }
+(( ${#JWT_SECRET} >= 32 )) || { echo "JWT_SECRET must contain at least 32 characters" >&2; exit 1; }
+
+umask 077
+bundle="$(mktemp -d "${RUNNER_TEMP:-/tmp}/twn-bundle.XXXXXX")"
+cleanup() {
+  local path
+  for path in "$bundle/app-secrets.json" "$bundle/ghcr-pull.json" "$bundle/docker-config.json"; do
+    if [[ -f "$path" ]]; then
+      shred -u -- "$path" 2>/dev/null || rm -f -- "$path"
+    fi
+  done
+  rm -rf -- "$bundle"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+cp -R "$SCRIPT_DIR/base" "$bundle/base"
+cp "$SCRIPT_DIR/deploy-on-node.sh" "$bundle/deploy-on-node.sh"
+
+jq -n \
+  --arg origin "$PUBLIC_ORIGIN" \
+  --arg region "$AWS_REGION" \
+  --arg bucket "$MEDIA_BUCKET" \
+  '{apiVersion:"v1",kind:"ConfigMap",metadata:{name:"runtime-config",namespace:"talk-with-neighbors"},data:{"public-origin":$origin,"cookie-secure":"false","media-storage-type":"s3","media-s3-region":$region,"media-s3-bucket":$bucket,"media-s3-prefix":"media"}}' \
+  > "$bundle/runtime-config.json"
+jq -n \
+  --arg mysql "$MYSQL_PASSWORD" \
+  --arg root "$MYSQL_ROOT_PASSWORD" \
+  --arg jwt "$JWT_SECRET" \
+  '{apiVersion:"v1",kind:"Secret",metadata:{name:"app-secrets",namespace:"talk-with-neighbors"},type:"Opaque",stringData:{"mysql-password":$mysql,"mysql-root-password":$root,"jwt-secret":$jwt}}' \
+  > "$bundle/app-secrets.json"
+
+if [[ -n "${GHCR_TOKEN:-}" && -n "${GHCR_USERNAME:-}" ]]; then
+  auth="$(printf '%s:%s' "$GHCR_USERNAME" "$GHCR_TOKEN" | base64 -w0)"
+  jq -n --arg auth "$auth" '{auths:{"ghcr.io":{auth:$auth}}}' > "$bundle/docker-config.json"
+else
+  jq -n '{auths:{}}' > "$bundle/docker-config.json"
+fi
+docker_config="$(base64 -w0 < "$bundle/docker-config.json")"
+jq -n \
+  --arg config "$docker_config" \
+  '{apiVersion:"v1",kind:"Secret",metadata:{name:"ghcr-pull",namespace:"talk-with-neighbors"},type:"kubernetes.io/dockerconfigjson",data:{".dockerconfigjson":$config}}' \
+  > "$bundle/ghcr-pull.json"
+shred -u -- "$bundle/docker-config.json" 2>/dev/null || rm -f -- "$bundle/docker-config.json"
+
+tar -C "$bundle" -czf "$OUTPUT_ARCHIVE" .
+echo "Deployment bundle created"

--- a/deploy/k8s/deploy-on-node.sh
+++ b/deploy/k8s/deploy-on-node.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly BACKEND_IMAGE="${1:-}"
+readonly FRONTEND_IMAGE="${2:-}"
+readonly RELEASE_ID="${3:-}"
+RELEASE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly RELEASE_DIR
+readonly NAMESPACE="talk-with-neighbors"
+readonly BACKEND_PLACEHOLDER="ghcr.io/gituserkhs/talk_with_neighbors_back@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+readonly FRONTEND_PLACEHOLDER="ghcr.io/gituserkhs/talk_with_neighbors_front@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+cleanup_plaintext_secrets() {
+  local path
+  for path in "$RELEASE_DIR/app-secrets.json" "$RELEASE_DIR/ghcr-pull.json"; do
+    if [[ -f "$path" ]]; then
+      shred -u -- "$path" 2>/dev/null || rm -f -- "$path"
+    fi
+  done
+}
+
+trap cleanup_plaintext_secrets EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[[ "$EUID" -eq 0 ]] || { echo "deploy-on-node.sh must run as root" >&2; exit 1; }
+[[ "$BACKEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_back@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid backend digest" >&2; exit 1; }
+[[ "$FRONTEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_front@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid frontend digest" >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9]+-[0-9]+$ ]] || { echo "Invalid release id" >&2; exit 1; }
+
+for _ in {1..120}; do
+  if command -v k3s >/dev/null 2>&1 && [[ -f /var/lib/rancher/k3s/server/node-ready ]]; then
+    break
+  fi
+  sleep 5
+done
+command -v k3s >/dev/null 2>&1 || { echo "k3s was not installed within 10 minutes" >&2; exit 1; }
+[[ -f /var/lib/rancher/k3s/server/node-ready ]] || { echo "k3s node did not become ready within 10 minutes" >&2; exit 1; }
+
+for required in \
+  "$RELEASE_DIR/base/kustomization.yaml" \
+  "$RELEASE_DIR/runtime-config.json" \
+  "$RELEASE_DIR/app-secrets.json" \
+  "$RELEASE_DIR/ghcr-pull.json"; do
+  [[ -s "$required" ]] || { echo "Missing deployment file: $required" >&2; exit 1; }
+done
+
+grep -Fq "$BACKEND_PLACEHOLDER" "$RELEASE_DIR/base/backend.yaml"
+grep -Fq "$FRONTEND_PLACEHOLDER" "$RELEASE_DIR/base/frontend.yaml"
+grep -Fq "REPLACE_RELEASE_ID" "$RELEASE_DIR/base/backend.yaml"
+sed -i "s#${BACKEND_PLACEHOLDER}#${BACKEND_IMAGE}#" "$RELEASE_DIR/base/backend.yaml"
+sed -i "s#${FRONTEND_PLACEHOLDER}#${FRONTEND_IMAGE}#" "$RELEASE_DIR/base/frontend.yaml"
+sed -i "s#REPLACE_RELEASE_ID#${RELEASE_ID}#" "$RELEASE_DIR/base/backend.yaml"
+grep -Fq "image: ${BACKEND_IMAGE}" "$RELEASE_DIR/base/backend.yaml"
+grep -Fq "image: ${FRONTEND_IMAGE}" "$RELEASE_DIR/base/frontend.yaml"
+grep -Fq "talkwithneighbors.io/release: ${RELEASE_ID}" "$RELEASE_DIR/base/backend.yaml"
+
+kubectl=(k3s kubectl)
+"${kubectl[@]}" wait --for=condition=Ready node --all --timeout=30s
+"${kubectl[@]}" apply -f "$RELEASE_DIR/base/namespace.yaml"
+"${kubectl[@]}" apply -f "$RELEASE_DIR/runtime-config.json"
+"${kubectl[@]}" apply -f "$RELEASE_DIR/app-secrets.json"
+"${kubectl[@]}" apply -f "$RELEASE_DIR/ghcr-pull.json"
+cleanup_plaintext_secrets
+"${kubectl[@]}" apply -k "$RELEASE_DIR/base"
+
+"${kubectl[@]}" -n "$NAMESPACE" rollout status statefulset/mysql --timeout=8m
+"${kubectl[@]}" -n "$NAMESPACE" rollout status statefulset/redis --timeout=5m
+"${kubectl[@]}" -n "$NAMESPACE" rollout status deployment/backend --timeout=10m
+"${kubectl[@]}" -n "$NAMESPACE" rollout status deployment/frontend --timeout=5m
+"${kubectl[@]}" -n "$NAMESPACE" exec deployment/backend -- \
+  wget -qO- http://127.0.0.1:8080/actuator/health/readiness \
+  | jq -e '.status == "UP"' >/dev/null
+
+echo "Release ${RELEASE_ID} is ready"

--- a/deploy/k8s/deploy-via-ssm.sh
+++ b/deploy/k8s/deploy-via-ssm.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly INSTANCE_ID="${1:?instance id is required}"
+readonly DEPLOY_BUCKET="${2:?deployment bucket is required}"
+readonly OBJECT_KEY="${3:?object key is required}"
+readonly BUNDLE_ARCHIVE="${4:?bundle archive is required}"
+readonly BACKEND_IMAGE="${5:?backend digest is required}"
+readonly FRONTEND_IMAGE="${6:?frontend digest is required}"
+readonly RELEASE_ID="${7:?release id is required}"
+readonly OBJECT_URI="s3://${DEPLOY_BUCKET}/${OBJECT_KEY}"
+
+[[ "$INSTANCE_ID" =~ ^i-[a-f0-9]{8,17}$ ]] || { echo "Invalid EC2 instance id" >&2; exit 1; }
+[[ "$DEPLOY_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || { echo "Invalid deployment bucket" >&2; exit 1; }
+[[ "$OBJECT_KEY" =~ ^deployments/[0-9]+-[0-9]+/bundle\.tgz$ ]] || { echo "Invalid deployment object key" >&2; exit 1; }
+[[ "$BACKEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_back@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid backend digest" >&2; exit 1; }
+[[ "$FRONTEND_IMAGE" =~ ^ghcr\.io/gituserkhs/talk_with_neighbors_front@sha256:[a-f0-9]{64}$ ]] || { echo "Invalid frontend digest" >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9]+-[0-9]+$ ]] || { echo "Invalid release id" >&2; exit 1; }
+[[ -s "$BUNDLE_ARCHIVE" ]] || { echo "Deployment bundle is missing" >&2; exit 1; }
+
+umask 077
+parameters_file="$(mktemp "${RUNNER_TEMP:-/tmp}/twn-ssm-parameters.XXXXXX.json")"
+command_id=""
+command_finished=false
+uploaded=false
+# Invoked through EXIT and signal traps.
+# shellcheck disable=SC2329
+cleanup() {
+  if [[ -n "$command_id" && "$command_finished" != true ]]; then
+    aws ssm cancel-command --command-id "$command_id" >/dev/null 2>&1 || true
+  fi
+  if [[ "$uploaded" == true ]]; then
+    aws s3 rm "$OBJECT_URI" --only-show-errors >/dev/null 2>&1 || true
+  fi
+  for path in "$BUNDLE_ARCHIVE" "$parameters_file"; do
+    if [[ -f "$path" ]]; then
+      shred -u -- "$path" 2>/dev/null || rm -f -- "$path"
+    fi
+  done
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+aws s3 cp "$BUNDLE_ARCHIVE" "$OBJECT_URI" --sse AES256 --only-show-errors
+uploaded=true
+
+jq -n \
+  --arg objectUri "$OBJECT_URI" \
+  --arg backend "$BACKEND_IMAGE" \
+  --arg frontend "$FRONTEND_IMAGE" \
+  --arg release "$RELEASE_ID" \
+  '{commands:[
+    "set -eu",
+    "umask 077",
+    "release_dir=/var/lib/talk-with-neighbors/release",
+    "cleanup_plaintext() { for path in /tmp/twn-deploy.tgz \"$release_dir/app-secrets.json\" \"$release_dir/ghcr-pull.json\"; do if [ -f \"$path\" ]; then shred -u -- \"$path\" 2>/dev/null || rm -f -- \"$path\"; fi; done; }",
+    "trap cleanup_plaintext EXIT",
+    "trap \"exit 129\" HUP",
+    "trap \"exit 130\" INT",
+    "trap \"exit 143\" TERM",
+    "install -d -m 0700 \"$release_dir\"",
+    "cleanup_plaintext",
+    ("aws s3 cp \"" + $objectUri + "\" /tmp/twn-deploy.tgz --only-show-errors"),
+    "find \"$release_dir\" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +",
+    "tar -xzf /tmp/twn-deploy.tgz -C \"$release_dir\"",
+    "shred -u -- /tmp/twn-deploy.tgz 2>/dev/null || rm -f -- /tmp/twn-deploy.tgz",
+    "chmod 0700 \"$release_dir/deploy-on-node.sh\"",
+    ("/bin/bash \"$release_dir/deploy-on-node.sh\" \"" + $backend + "\" \"" + $frontend + "\" \"" + $release + "\"")
+  ],executionTimeout:["2400"]}' > "$parameters_file"
+
+command_id="$(aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --parameters "file://${parameters_file}" \
+  --timeout-seconds 120 \
+  --comment "talk-with-neighbors ${RELEASE_ID}" \
+  --query 'Command.CommandId' \
+  --output text)"
+[[ -n "$command_id" && "$command_id" != "None" ]] || { echo "SSM did not return a command id" >&2; exit 1; }
+echo "SSM command: $command_id"
+
+for _ in {1..270}; do
+  status="$(aws ssm get-command-invocation \
+    --command-id "$command_id" \
+    --instance-id "$INSTANCE_ID" \
+    --query Status \
+    --output text 2>/dev/null || true)"
+  case "$status" in
+    Success)
+      command_finished=true
+      aws ssm get-command-invocation --command-id "$command_id" --instance-id "$INSTANCE_ID" --query StandardOutputContent --output text
+      exit 0
+      ;;
+    Failed|Cancelled|TimedOut|Cancelling)
+      command_finished=true
+      aws ssm get-command-invocation --command-id "$command_id" --instance-id "$INSTANCE_ID" --query '[StandardOutputContent,StandardErrorContent]' --output text || true
+      echo "SSM deployment failed with status $status" >&2
+      exit 1
+      ;;
+    Pending|InProgress|Delayed|"")
+      sleep 10
+      ;;
+    *)
+      echo "Unexpected SSM status: $status" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "SSM deployment exceeded 45 minutes" >&2
+exit 1

--- a/deploy/k8s/runtime-config.example.yaml
+++ b/deploy/k8s/runtime-config.example.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runtime-config
+  namespace: talk-with-neighbors
+data:
+  # Use the exact browser origin. Switch cookie-secure to true with HTTPS.
+  public-origin: http://203.0.113.10
+  cookie-secure: "false"
+  # The EC2 instance role supplies short-lived credentials; never put AWS keys here.
+  media-storage-type: s3
+  media-s3-region: ap-northeast-2
+  media-s3-bucket: replace-with-terraform-media-bucket-output
+  media-s3-prefix: media

--- a/deploy/k8s/secrets.example.yaml
+++ b/deploy/k8s/secrets.example.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: talk-with-neighbors
+type: Opaque
+stringData:
+  mysql-password: REPLACE_WITH_A_RANDOM_PASSWORD
+  mysql-root-password: REPLACE_WITH_A_DIFFERENT_RANDOM_PASSWORD
+  jwt-secret: REPLACE_WITH_AT_LEAST_32_RANDOM_BYTES
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-pull
+  namespace: talk-with-neighbors
+type: kubernetes.io/dockerconfigjson
+data:
+  # `echo -n '{"auths":{}}' | base64` works for public GHCR packages.
+  .dockerconfigjson: eyJhdXRocyI6e319

--- a/docs/01-system-overview.md
+++ b/docs/01-system-overview.md
@@ -36,7 +36,7 @@ flowchart LR
 | 임시 저장소 | Redis 7.4 | 세션, 온라인 상태, 대기 중 매칭, 현재 채팅방 |
 | 프록시 | Nginx | SPA 제공, `/api`, `/ws`, `/uploads` 역방향 프록시 |
 | 실행 | Docker Compose | 프론트, 백엔드, MySQL, Redis 통합 실행 |
-| 자동화 | GitHub Actions | 타입 검사, 테스트, 빌드; 외부 배포 워크플로는 비활성화 |
+| 자동화 | GitHub Actions, Terraform, Kustomize | 테스트·이미지 게시·k3s 배포; 인프라 생성은 승인 후 수동 적용 |
 
 ## 저장소 구조
 

--- a/docs/06-operations-and-cicd.md
+++ b/docs/06-operations-and-cicd.md
@@ -66,12 +66,13 @@ flowchart TD
 PR과 `main`, `codex/**` 푸시에서 다음을 실행한다.
 
 1. `npm ci`
-2. `npm run typecheck`
-3. `npm run build`
+2. `npm test`
+3. 같은 출처(`/api`, `/ws`) 설정으로 `npm run build`
 4. 프로덕션 Docker 이미지 빌드
-5. `dist` 아티팩트 보관
+5. 실제 Nginx 컨테이너 `/healthz`와 SPA 응답 스모크 테스트
+6. `dist` 아티팩트 보관
 
-GitHub Pages와 프론트 이미지 게시 워크플로는 로컬 전용 운영 방침에 따라 수동 비활성화 상태다.
+GitHub Pages는 공개 API 주소를 명시해야 하는 수동 미리보기다. `main`과 버전 태그의 프론트 이미지는 위 품질 검증을 통과한 뒤 GHCR에 게시된다.
 
 ## 백엔드 CI/CD
 
@@ -81,9 +82,16 @@ PR과 `main`, `codex/**` 푸시에서 다음을 실행한다.
 2. `./gradlew clean test bootJar --no-daemon`
 3. `compose.production.yml` 구성 검증
 4. 프로덕션 Docker 이미지 빌드
-5. 테스트 보고서 보관
+5. 실제 MySQL 8·Redis 7과 함께 컨테이너 readiness 및 DB 조회 스모크 테스트
+6. 테스트 보고서 보관
 
-백엔드 이미지 게시 워크플로는 로컬 전용 운영 방침에 따라 수동 비활성화 상태다.
+`main`과 버전 태그의 백엔드 이미지는 별도 품질 작업이 성공한 뒤에만 GHCR에 게시된다. 게시 이미지에는 provenance와 SBOM attestation을 생성한다.
+
+## AWS 인프라와 k3s 배포
+
+백엔드 저장소의 `infra/aws-ec2/`는 서울 리전 EC2, VPC, S3, SSM, 비용 알림과 GitHub OIDC 배포 역할을 관리한다. `deploy/k8s/base/`는 단일 노드 k3s의 MySQL, Redis, 백엔드, 프론트엔드와 Traefik Ingress를 관리하며 미디어 원본과 변환 결과는 비공개 S3 버킷에 저장한다.
+
+`infra-ci.yml`은 Terraform 형식·스키마, Kustomize 렌더링, Kubernetes 스키마, GitHub Actions 문법을 검증하지만 비용이 발생하는 `terraform apply`는 실행하지 않는다. `deploy-k3s.yml`은 승인된 `production` Environment에서 고정된 GHCR digest만 받아 임시 S3 번들과 SSM Run Command로 배포하고 rollout·readiness·외부 API를 확인한다. SSH 22는 열지 않는다. 자세한 생성·비용 관리·롤백·삭제 절차는 [AWS EC2 + S3 + k3s 배포 가이드](deployment/aws-k3s.md)를 따른다.
 
 ## 참고용 운영 Compose
 
@@ -92,7 +100,7 @@ PR과 `main`, `codex/**` 푸시에서 다음을 실행한다.
 - `ghcr.io/gituserkhs/talk_with_neighbors_front:${IMAGE_TAG:-latest}`
 - `ghcr.io/gituserkhs/talk_with_neighbors_back:${IMAGE_TAG:-latest}`
 
-이 구성은 참고용으로 남아 있으며 현재 자동 게시되는 이미지가 없으므로 로컬 운영에는 사용하지 않는다.
+이 구성은 Kubernetes 없이 한 서버에서 GHCR 이미지를 점검할 때 사용할 수 있다. 업로드 미디어도 `media_data` 볼륨에 보존하지만, 새 배포는 SHA 태그를 명시하고 HTTPS·백업을 별도로 준비해야 한다.
 
 ```bash
 docker compose -f compose.production.yml up -d

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 8. [제품 기능 백로그](08-product-backlog.md) — 다음 기능 후보와 우선순위
 9. [사용자 안전 기능](09-safety-and-moderation.md) — 차단·신고·콘텐츠 숨김 정책과 API
 10. [제품 확장 기능](10-product-expansion.md) — 영구 알림함, 온보딩, 모임 일정, 프라이버시, 설명형 매칭
+11. [AWS EC2 + S3 + k3s 배포](deployment/aws-k3s.md) — 포트폴리오용 저비용 구조, Terraform, OIDC·SSM 배포, 테스트·비용 관리
 
 ## 빠른 시작
 

--- a/docs/deployment/aws-k3s.md
+++ b/docs/deployment/aws-k3s.md
@@ -1,0 +1,468 @@
+# AWS EC2 + S3 + 단일 노드 k3s 배포 가이드
+
+이 문서는 `talk_with_neighbors`를 서울 리전의 저비용 AWS 환경에 배포하는 절차를 설명한다. 대상은 실제 상용 서비스가 아니라 **DevOps·백엔드 포트폴리오와 짧은 데모**다. 관리형 EKS 대신 ARM64 EC2 한 대의 k3s를 사용하고, 미디어만 비공개 S3로 분리한다.
+
+> **현재 상태 — 2026-07-14:** Terraform, Kubernetes 매니페스트, GitHub Actions 배포 자동화는 저장소에 구현되어 있지만 **실제 AWS 계정에서 `terraform apply`는 아직 실행하지 않았다.** 따라서 이 저장소 작업만으로 생성된 AWS 리소스나 청구는 없다. 아래의 `terraform apply`부터가 실제 리소스 생성·과금 경계다.
+
+이 구성은 고가용성, 무중단 배포, 자동 DB 백업을 보장하지 않는다. 실제 사용자 계정과 비밀번호를 받는 공개 서비스로 사용하기 전에는 최소한 고정 주소, 도메인, TLS, DB 백업을 추가해야 한다.
+
+## 1. 선택한 구조
+
+```mermaid
+flowchart LR
+    U["사용자 브라우저"] -->|"HTTP 80"| IP["EC2 동적 Public IPv4"]
+    IP --> T["k3s Traefik Ingress"]
+    T -->|"/"| F["React + Nginx"]
+    T -->|"/api · /ws · /uploads"| B["Spring Boot"]
+    B --> M["MySQL StatefulSet"]
+    B --> R["Redis StatefulSet"]
+    M --> E["암호화된 30 GiB gp3 · local-path PVC"]
+    R --> E
+    B -->|"EC2 Instance Role · media/ prefix"| S3["비공개·버전 관리 S3 미디어 버킷"]
+
+    G["GitHub Actions · production"] -->|"OIDC 임시 자격 증명"| IAM["최소 권한 IAM Role"]
+    IAM -->|"암호화된 단기 번들"| DS3["비공개 배포 S3 버킷"]
+    IAM -->|"SSM Run Command"| EC2["EC2 t4g.small · Ubuntu 24.04 ARM64"]
+    DS3 -->|"Instance Role로 읽기"| EC2
+    EC2 --> T
+```
+
+| 구성 요소 | 현재 선택 | 이유와 한계 |
+|---|---|---|
+| 컴퓨트 | `t4g.small`, 2 vCPU·2 GiB, ARM64 | 저비용 포트폴리오 기본값. k3s·JVM·MySQL·Redis를 한 노드에서 돌리므로 2 GiB swap과 보수적인 컨테이너 제한을 사용한다. |
+| 루트 디스크 | 암호화된 30 GiB gp3 | k3s 이미지·로그·MySQL PVC를 함께 저장한다. EC2를 중지해도 유지되고 과금될 수 있으며, 인스턴스 종료 시 삭제된다. |
+| 오케스트레이션 | 단일 노드 k3s + Traefik | EKS 제어부 비용을 피하지만 노드 장애가 곧 전체 서비스 장애다. |
+| 미디어 | 비공개·버전 관리 S3 | 앱이 `/uploads/**`로 프록시한다. 브라우저에 버킷이나 AWS 키를 노출하지 않는다. |
+| 배포 | GitHub OIDC → S3 번들 → SSM | 장기 AWS 액세스 키와 SSH 22 포트를 사용하지 않는다. |
+| 네트워크 | Public subnet + Internet Gateway | NAT Gateway, Load Balancer, Elastic IP는 만들지 않는다. 대신 중지·시작 후 공인 IP가 바뀐다. |
+| 외부 프로토콜 | 기본은 HTTP 80 | 보안 그룹의 443은 향후 TLS용으로 열려 있지만 현재 Ingress에는 인증서와 HTTPS 라우터가 없다. |
+
+S3 Gateway VPC Endpoint를 사용해 EC2와 S3 사이 경로에 NAT Gateway가 필요하지 않다. Gateway 유형 자체에는 시간당 엔드포인트 요금이 없지만 S3 저장·요청·인터넷 전송 요금은 별도다.
+
+## 2. Terraform이 만드는 리소스
+
+`infra/aws-ec2/`는 다음을 관리한다.
+
+- 전용 VPC, Public subnet 한 개, Internet Gateway, Route Table
+- 시간당 요금이 없는 S3 Gateway VPC Endpoint
+- 80·443만 인바운드로 허용하고 22는 열지 않는 Security Group
+- Canonical Ubuntu 24.04 ARM64 AMI의 `t4g.small` EC2
+- 암호화·종료 시 삭제되는 30 GiB gp3 루트 볼륨
+- 2 GiB swap, 고정된 k3s 버전, secrets encryption을 설정하는 최초 부팅 스크립트
+- SSM 관리 권한과 `media/`·`deployments/` prefix만 허용하는 EC2 Instance Role
+- 공개 접근 차단, SSE-S3, TLS 외 접근 거부를 적용한 미디어·배포 버킷
+- 미디어 버킷 버전 관리와 비현재 버전 기본 30일 보존
+- 배포 번들을 하루 뒤 정리하는 별도 S3 lifecycle
+- GitHub `production` Environment subject만 신뢰하는 OIDC 배포 Role
+- 이메일을 지정했을 때만 생성되는 월 비용 Budget
+
+미디어와 배포 버킷은 기본적으로 `force_destroy = false`다. 실수로 Terraform을 실행해도 비어 있지 않은 버킷을 즉시 삭제하지 못하게 하는 보호 장치다.
+
+## 3. 비용과 Free Tier
+
+2025년 7월 15일 이후 만든 신규 계정은 가입 시 USD 100 크레딧을 받고 활동 완료로 최대 USD 100를 추가로 받을 수 있다. Free account plan은 계정 생성 후 6개월 또는 크레딧 소진 중 먼저 오는 시점까지다. `t4g.small`과 gp3는 신규 계정의 Free Tier eligible 목록에 있지만, **eligible은 모든 사용량이 영구 무료라는 뜻이 아니다.** 계정 plan, 남은 크레딧, AMI와 리전 조건을 Billing 화면에서 직접 확인한다.
+
+2026-07-14 현재 AWS의 T4g 안내에는 `t4g.small`을 2026-12-31까지 월 최대 750시간 시험할 수 있다고도 명시되어 있다. 이 혜택이 계정과 선택한 Ubuntu AMI에 실제 적용되는지는 EC2 생성 화면과 청구서에서 확인한다. 컴퓨트 혜택이 적용되어도 EBS, S3, Public IPv4, snapshot, 초과 데이터 전송이 자동으로 모두 무료가 되는 것은 아니다.
+
+- [신규 AWS Free Tier 안내](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/free-tier.html)
+- [EC2 Free Tier 대상과 사용량 확인](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-free-tier-usage.html)
+- [EC2 T4g 사양과 기간 한정 시험 안내](https://aws.amazon.com/ec2/instance-types/t4/)
+- [EC2 On-Demand 가격](https://aws.amazon.com/ec2/pricing/on-demand/)
+- [EBS 가격](https://aws.amazon.com/ebs/pricing/)
+- [S3 가격](https://aws.amazon.com/s3/pricing/)
+- [Public IPv4 과금 설명](https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html)
+
+가격은 리전·계정 혜택·세금·환율에 따라 바뀌므로 문서에 고정 월액을 약속하지 않는다. 적용 직전 [AWS Pricing Calculator](https://calculator.aws/)로 서울 리전의 현재 단가를 다시 계산한다.
+
+| 비용 항목 | 언제 비용이 생기는가 | 절약 방법 |
+|---|---|---|
+| EC2 compute | 인스턴스가 `running`인 시간 | 데모할 때만 시작하고 끝나면 중지한다. `t4g.small` CPU credit은 `standard`로 고정해 unlimited 추가 요금을 피한다. |
+| Public IPv4 | 실행 중 EC2에 할당된 공인 IPv4 사용 시간. Free Tier 대상 계정은 EC2용 월 750시간 혜택이 있을 수 있다. | 인스턴스를 중지하면 동적 IP가 해제된다. Elastic IP는 만들지 않는다. |
+| EBS gp3 | 30 GiB 볼륨이 존재하는 동안. EC2를 중지해도 계속 존재한다. | 이미지·로그를 정리하고 필요 없으면 `terraform destroy`로 종료한다. |
+| S3 미디어 | 현재 객체와 보존 중인 비현재 버전의 GB-month, PUT·GET·LIST, 인터넷 전송 | 비현재 버전은 기본 30일 뒤 만료한다. 큰 테스트 파일과 불필요한 현재 객체는 직접 삭제한다. |
+| S3 배포 번들 | 배포할 때의 짧은 저장·요청 | 성공·실패 시 스크립트가 삭제하고, 누락된 객체도 하루 뒤 lifecycle로 만료한다. |
+| 스냅샷·데이터 전송 | 수동 EBS snapshot, 인터넷 outbound 등 | 스냅샷 보존 기한을 정하고 Billing에서 전송량을 확인한다. |
+| AWS Budget | 이메일을 지정했을 때 월 Budget 생성 | 알림은 지출을 차단하지 않는다. 실제 사용 중지·삭제는 별도로 해야 한다. |
+
+`budget_alert_email`을 설정하면 기본 USD 10 월 Budget에서 실제 80%, 예측 100% 알림을 보낸다. 크레딧이 있어도 **Billing → Credits, Free Tier, Bills, Cost Explorer**를 함께 확인한다.
+
+## 4. 사전 준비
+
+다음이 필요하다.
+
+- AWS CLI v2와 Terraform `>= 1.8, < 2.0`
+- 서울 리전에서 VPC, EC2, EBS, S3, IAM, SSM, Budget을 만들 수 있는 로컬 AWS 주체
+- 백엔드 GitHub 저장소 관리자 권한
+- GHCR에 게시된 ARM64 포함 다중 아키텍처 백엔드·프론트엔드 이미지
+- GitHub `production` Environment의 승인자를 정할 계정
+
+루트 사용자의 장기 액세스 키는 만들지 않는다. 로컬 CLI는 가능한 한 AWS IAM Identity Center나 수명이 짧은 관리자 세션을 사용하고, 먼저 대상 계정을 확인한다.
+
+```powershell
+aws sts get-caller-identity
+aws configure get region
+terraform version
+```
+
+출력의 AWS Account ID와 ARN이 의도한 포트폴리오 계정인지 확인한다. 다른 계정이면 여기서 멈춘다.
+
+## 5. 과금 없이 검증하기
+
+저장소의 인프라 CI는 `terraform apply`를 호출하지 않는다. PR에서 다음을 검증한다.
+
+- Terraform `fmt`, provider 초기화, `validate`
+- Kustomize 렌더링과 kubeconform Kubernetes 스키마 검사
+- 배포 Bash의 ShellCheck
+- GitHub Actions의 actionlint
+
+로컬에서도 먼저 정적 검증과 mock 기반 기본값 테스트를 실행할 수 있다.
+
+```powershell
+Set-Location infra\aws-ec2
+terraform init -backend=false -input=false
+terraform fmt -check -recursive
+terraform validate
+terraform test
+```
+
+`terraform init`은 provider를 내려받지만 AWS 리소스를 만들지 않는다. 실제 계정 조회와 생성 계획은 다음 절의 `plan`부터 시작한다.
+
+## 6. Terraform 계획과 최초 생성
+
+### 6.1 변수 준비
+
+백엔드 저장소 루트에서 실행한다.
+
+```powershell
+Set-Location infra\aws-ec2
+Copy-Item terraform.tfvars.example terraform.tfvars
+```
+
+기본 예시는 다음 선택을 담고 있다.
+
+```hcl
+aws_region        = "ap-northeast-2"
+availability_zone = "ap-northeast-2a"
+
+instance_type        = "t4g.small"
+root_volume_size_gib = 30
+k3s_version          = "v1.34.8+k3s1"
+
+# 삭제된 미디어의 비현재 버전을 약 30일 동안만 복구 가능하게 유지한다.
+media_noncurrent_version_expiration_days = 30
+media_bucket_force_destroy                = false
+
+github_owner       = "gitUserKHS"
+github_repository  = "talk_with_neighbors_back"
+github_environment = "production"
+
+# 선택: 월 USD 10 Budget과 이메일 알림
+budget_alert_email = "you@example.com"
+monthly_budget_usd = 10
+```
+
+계정에 `https://token.actions.githubusercontent.com` OIDC provider가 이미 있으면 새로 만들지 않도록 기존 ARN을 넣는다.
+
+```hcl
+github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+```
+
+`terraform.tfvars`, `*.tfstate*`, `tfplan`은 커밋하지 않는다. 현재 상태는 로컬 backend이므로 상태 파일을 암호화된 안전한 위치에 백업한다. 팀 운영으로 바꾸면 잠금과 암호화를 지원하는 remote state를 먼저 도입한다.
+
+### 6.2 계획 검토
+
+```powershell
+terraform init
+terraform fmt -check -recursive
+terraform validate
+terraform plan -out=tfplan
+terraform show tfplan
+```
+
+적용 전에 최소한 다음을 확인한다.
+
+- Account와 리전이 의도한 계정, `ap-northeast-2`인가
+- AMI는 Ubuntu 24.04 ARM64이고 인스턴스는 `t4g.small`인가
+- 루트 볼륨은 암호화된 gp3 30 GiB이며 `delete_on_termination = true`인가
+- 인바운드는 80·443뿐이고 22·3306·6379·8080은 공개되지 않았는가
+- NAT Gateway, Load Balancer, Elastic IP, EKS가 계획에 없는가
+- OIDC subject가 정확히 `repo:gitUserKHS/talk_with_neighbors_back:environment:production`인가
+- 미디어 버킷은 versioning·public access block·30일 비현재 버전 lifecycle을 갖는가
+- `force_destroy`가 두 버킷 모두 `false`인가
+- Budget 이메일과 한도가 의도한 값인가
+
+### 6.3 명시적으로 생성
+
+다음 명령은 AWS 리소스를 만들며 비용이 발생할 수 있다. 검토한 `tfplan`과 대상 계정을 다시 확인한 뒤에만 직접 실행한다.
+
+```powershell
+terraform apply tfplan
+terraform output
+```
+
+최초 부팅은 swap, AWS CLI, SSM Agent, k3s를 설치한다. 몇 분 걸릴 수 있다. SSH 대신 다음으로 상태를 확인한다.
+
+```powershell
+$InstanceId = terraform output -raw instance_id
+aws ec2 wait instance-status-ok --region ap-northeast-2 --instance-ids $InstanceId
+
+aws ssm describe-instance-information `
+  --region ap-northeast-2 `
+  --filters "Key=InstanceIds,Values=$InstanceId" `
+  --query "InstanceInformationList[0].[PingStatus,PlatformName,AgentVersion]" `
+  --output table
+```
+
+`PingStatus`가 `Online`이어야 GitHub 배포가 가능하다. Bootstrap 실패는 SSM Session Manager나 EC2 Serial Console 권한을 별도로 준비해 `/var/log/talk-with-neighbors-bootstrap.log`와 `journalctl -u k3s`를 확인한다. 보안 그룹에 임시 SSH 22를 추가하는 절차는 기본 운영 경로가 아니다.
+
+## 7. GitHub `production` Environment 설정
+
+백엔드 저장소의 **Settings → Environments → production**을 만든다.
+
+- Deployment branches는 `main`만 허용한다.
+- Required reviewers를 최소 한 명 지정한다.
+- 가능하면 관리자 우회 배포를 막는다.
+- OIDC Role의 `github_environment` 이름과 철자·대소문자가 같아야 한다.
+
+Terraform 출력값을 Environment variables로 등록한다.
+
+| Variable | 값 |
+|---|---|
+| `AWS_REGION` | `ap-northeast-2` |
+| `AWS_DEPLOY_ROLE_ARN` | `terraform output -raw github_deploy_role_arn` |
+| `EC2_INSTANCE_ID` | `terraform output -raw instance_id` |
+| `DEPLOY_BUCKET` | `terraform output -raw deployment_bucket_name` |
+| `MEDIA_BUCKET` | `terraform output -raw media_bucket_name` |
+
+Environment secrets는 다음과 같다.
+
+| Secret | 규칙 |
+|---|---|
+| `MYSQL_PASSWORD` | 앱 전용 DB 사용자 비밀번호, 서로 다른 난수 16자 이상 |
+| `MYSQL_ROOT_PASSWORD` | MySQL root 비밀번호, 서로 다른 난수 16자 이상 |
+| `JWT_SECRET` | JWT 서명용 난수 32자 이상 |
+| `GHCR_USERNAME` | private GHCR 이미지를 읽을 사용자. 패키지가 public이면 비워도 된다. |
+| `GHCR_TOKEN` | 위 사용자의 최소 `read:packages` 토큰. `GHCR_USERNAME`과 함께 설정하거나 둘 다 비운다. |
+
+AWS access key와 secret key는 GitHub에 저장하지 않는다. GitHub Actions는 `id-token: write`로 OIDC 토큰을 받아 1시간 이하의 임시 AWS 자격 증명으로 교환한다. 신뢰 정책은 지정 저장소의 `production` Environment subject만 허용한다. 자세한 원리는 [AWS IAM OIDC](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)와 [GitHub AWS OIDC 가이드](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws)를 참고한다.
+
+애플리케이션 secret은 실행 시 private 배포 버킷을 거쳐 Kubernetes Secret으로 적용된다. runner와 노드의 평문 임시 파일은 성공·실패와 관계없이 정리하고, 배포 버킷 lifecycle이 하루 뒤 잔여 객체를 정리한다. k3s secrets encryption도 켜져 있지만 클러스터 관리자와 EC2 root는 Secret을 읽을 수 있으므로 이들을 신뢰 경계로 본다.
+
+## 8. 이미지 게시와 배포
+
+### 8.1 검증된 다중 아키텍처 이미지 만들기
+
+EC2가 Graviton ARM64이므로 백엔드와 프론트엔드 이미지는 반드시 `linux/amd64,linux/arm64`를 포함해야 한다. 각 저장소의 `publish-image.yml`은 다음 순서로 처리한다.
+
+1. 단위·통합 테스트와 프로덕션 빌드를 통과한다.
+2. 격리된 candidate tag로 다중 아키텍처 이미지를 GHCR에 push한다.
+3. push된 정확한 digest를 Trivy로 `HIGH`, `CRITICAL` 취약점 검사한다.
+4. 같은 digest를 컨테이너 스모크 테스트한다.
+5. 성공한 digest만 `main`, commit SHA, `latest` tag로 승격한다.
+
+배포에는 변경 가능한 tag가 아니라 워크플로 summary의 불변 주소를 사용한다.
+
+```text
+ghcr.io/gituserkhs/talk_with_neighbors_back@sha256:<64자리 digest>
+ghcr.io/gituserkhs/talk_with_neighbors_front@sha256:<64자리 digest>
+```
+
+### 8.2 배포 실행
+
+백엔드 저장소의 **Actions → Deploy EC2 k3s production → Run workflow**에서 `main`을 선택한다.
+
+| 입력 | 내용 |
+|---|---|
+| `backend_image` | 백엔드의 전체 GHCR digest 주소 |
+| `frontend_image` | 프론트엔드의 전체 GHCR digest 주소 |
+| `public_origin` | 보통 비운다. 현재 EC2 공인 IP로 `http://...`를 자동 계산한다. |
+| `start_if_stopped` | EC2가 중지되어 있으면 시작하고 배포하려면 체크한다. |
+
+워크플로는 다음을 자동 수행한다.
+
+1. `main`, Environment 승인, digest 형식, secret 길이를 검증한다.
+2. OIDC로 AWS 임시 자격 증명을 받는다.
+3. 선택 시 EC2를 시작하고 현재 동적 공인 IP와 SSM `Online` 상태를 확인한다.
+4. S3·DB·JWT·선택적 GHCR 설정이 든 private 배포 번들을 만든다.
+5. 번들을 SSE-S3로 업로드하고 SSM `AWS-RunShellScript`를 실행한다.
+6. 노드에서 정확한 이미지 digest를 매니페스트에 주입하고 k3s에 적용한다.
+7. MySQL, Redis, 백엔드, 프론트엔드 rollout과 백엔드 readiness를 확인한다.
+8. 외부 `/healthz` 응답 본문과 실제 DB 조회 API를 엄격하게 스모크 테스트한다.
+9. runner·S3·노드의 평문 임시 파일을 정리한다.
+
+배포 번들은 secret을 포함하므로 콘솔에서 다운로드하거나 보관하지 않는다. 배포 Role은 지정 instance와 deployment prefix에만 필요한 권한을 갖고, EC2 Role은 media·deployment prefix만 접근한다. 애플리케이션에는 정적 AWS 키를 주입하지 않고 EC2 Instance Role의 임시 자격 증명을 사용한다.
+
+### 8.3 수동 확인
+
+배포 summary의 URL로 다음을 확인한다.
+
+```powershell
+$Origin = "http://<현재-공인-IP>"
+curl.exe --fail --show-error "$Origin/healthz"
+curl.exe --fail --show-error "$Origin/api/auth/check-duplicates?email=smoke%40example.invalid&username=smoke"
+```
+
+추가 수동 시나리오는 최소 다음을 포함한다.
+
+- 서로 다른 세 사용자 가입·로그인과 세션 유지
+- 게시글·댓글 작성, 수정, 삭제와 숨김·차단 권한
+- WebSocket 채팅 송수신, 재접속, 메시지 수정·삭제
+- 이미지 여러 장, 동영상, 파일 업로드·Range 재생·다운로드
+- 업로드 후 백엔드 Pod 재시작에도 S3 미디어가 유지되는지
+- EC2 재부팅 후 MySQL·Redis PVC와 S3 미디어가 유지되는지
+- 80·443 외 22·3306·6379·8080이 인터넷에 공개되지 않았는지
+
+배포 자동화의 스모크 테스트가 전체 사용자 여정을 대신하지는 않는다.
+
+## 9. 중지·시작과 동적 IP
+
+백엔드 저장소의 **Actions → Control portfolio EC2**에서 `status`, `start`, `stop`을 실행할 수 있다. 이 워크플로도 `production` 승인과 OIDC를 사용한다.
+
+CLI로 직접 실행하려면 다음과 같다.
+
+```powershell
+$InstanceId = terraform -chdir=infra/aws-ec2 output -raw instance_id
+aws ec2 stop-instances --region ap-northeast-2 --instance-ids $InstanceId
+aws ec2 wait instance-stopped --region ap-northeast-2 --instance-ids $InstanceId
+
+aws ec2 start-instances --region ap-northeast-2 --instance-ids $InstanceId
+aws ec2 wait instance-running --region ap-northeast-2 --instance-ids $InstanceId
+aws ec2 describe-instances --region ap-northeast-2 --instance-ids $InstanceId `
+  --query "Reservations[0].Instances[0].PublicIpAddress" --output text
+```
+
+중지는 종료가 아니다. 중지 중에는 EC2 compute 과금이 멈추지만 EBS와 S3는 남고 비용이 발생할 수 있다.
+
+Elastic IP가 없으므로 stop/start 뒤 Public IPv4가 바뀐다. **시작만 하지 말고 `Deploy EC2 k3s production`을 다시 실행하는 것을 기본 절차로 삼는다.** 워크플로가 새 IP를 `public-origin`과 CORS 설정에 반영하고 외부 스모크 테스트까지 다시 수행한다. 가장 간단한 방법은 배포 워크플로에서 `start_if_stopped = true`를 선택하는 것이다.
+
+## 10. 현재 HTTP 한계
+
+기본 Ingress는 `web` entrypoint만 사용하고 배포 스크립트도 `http://` origin만 허용한다. 443 Security Group 규칙이 있어도 TLS 인증서와 HTTPS listener가 자동 생성되는 것은 아니다.
+
+따라서 현재 배포는 짧은 포트폴리오 시연 전용이다.
+
+- 공용 네트워크에서 실제 비밀번호나 민감한 채팅을 입력하지 않는다.
+- 브라우저의 Secure cookie를 켤 수 없으므로 세션 보호가 완전하지 않다.
+- 동적 IP라 URL이 안정적이지 않다.
+- 프론트엔드와 미디어도 CloudFront 없이 단일 EC2를 통과한다.
+
+실제 공개 전에 다음을 별도 변경으로 구현한다.
+
+1. Elastic IP 또는 안정된 앞단을 선택하고 비용을 계산한다.
+2. 도메인 DNS를 연결한다.
+3. Traefik에 유효한 TLS 인증서 발급·갱신과 HTTP→HTTPS redirect를 구성한다.
+4. 배포 입력과 runtime config가 `https://`와 `cookie-secure = true`를 지원하게 바꾼다.
+5. HSTS, WebSocket `wss://`, CORS, 업로드·다운로드를 다시 테스트한다.
+
+## 11. 관찰과 장애 조사
+
+SSH 없이 SSM Run Command나 Session Manager를 사용한다. 배포 실패 시 GitHub Actions에는 SSM 표준 출력·오류가 남는다. 추가로 확인할 항목은 다음과 같다.
+
+```bash
+sudo k3s kubectl get nodes
+sudo k3s kubectl -n talk-with-neighbors get pods,pvc,ingress
+sudo k3s kubectl -n talk-with-neighbors describe pod <pod-name>
+sudo k3s kubectl -n talk-with-neighbors logs deployment/backend --tail=300
+sudo journalctl -u k3s --no-pager -n 300
+sudo tail -n 300 /var/log/talk-with-neighbors-bootstrap.log
+```
+
+현재 구성에는 CloudWatch Container Insights나 중앙 로그 수집이 없다. 비용을 아끼는 대신 인스턴스가 손상되면 로컬 로그도 사라질 수 있다. 포트폴리오 시연 중에는 최소한 GitHub 배포 로그, SSM command ID, 이미지 digest, 테스트 결과를 릴리스 증적으로 남긴다.
+
+### 11.1 OS·AMI·k3s 업그레이드
+
+MySQL과 Redis가 EC2 루트 EBS에 있기 때문에 Canonical의 `current` AMI나 bootstrap 변경만으로 인스턴스가 자동 교체되면 데이터가 사라질 수 있다. 이를 막기 위해 Terraform은 `ami`와 `user_data` 변경을 무시하고 `user_data_replace_on_change = false`를 사용한다. 따라서 새 AMI나 bootstrap 값이 plan에 바로 반영되지 않는 것은 의도된 동작이다.
+
+보안 업데이트는 SSM으로 기존 노드에 적용하고, k3s 업그레이드는 DB 논리 백업과 EBS snapshot을 만든 뒤 별도의 유지보수 작업으로 수행한다. 새 AMI로 교체해야 할 때는 자동 교체에 맡기지 말고 새 노드 생성, DB 복원, S3 연결, 애플리케이션 검증, 트래픽 전환 순서를 명시적으로 계획한다.
+
+## 12. 롤백과 데이터 복구
+
+### 12.1 애플리케이션 롤백
+
+자동으로 이전 버전으로 되돌리는 blind rollback은 하지 않는다. 마지막으로 정상 확인한 백엔드·프론트엔드 digest를 `deploy-k3s.yml`에 다시 입력하고 동일한 rollout·readiness·외부 스모크 테스트를 거친다.
+
+DB schema 변경은 이미지 롤백으로 되돌아가지 않는다. 현재는 Hibernate `ddl-auto=update`를 사용하고 Flyway 같은 명시적 migration 도구가 아직 없으므로, 공개 운영 전에 migration을 버전 관리하고 하위 호환 가능한 expand/contract 방식으로 나눠야 한다. 파괴적 migration 전에는 논리 백업과 복구 시험을 먼저 한다.
+
+### 12.2 MySQL과 노드 디스크
+
+MySQL은 EC2 루트 EBS의 local-path PVC에 있다. EC2 stop/start에는 유지되지만 인스턴스 종료나 볼륨 손상에는 안전하지 않다. 현재 자동 `mysqldump`, 별도 RDS, 자동 EBS snapshot은 구현되어 있지 않다.
+
+중요한 데모 데이터가 생기기 전 최소 운영 보강은 다음과 같다.
+
+1. 정기 `mysqldump`를 암호화된 별도 백업 위치에 저장한다.
+2. 복원용 빈 DB에서 실제로 dump를 복구해 본다.
+3. 파괴적 작업 전 앱을 중지하고 수동 EBS snapshot을 만든다.
+4. snapshot 완료 상태와 보존 기한을 기록한다.
+
+EBS snapshot은 별도 비용이 들고 Terraform이 관리하지 않으므로, 인프라를 삭제한 뒤에도 남아 과금될 수 있다. 파일 시스템 snapshot만으로 MySQL 논리 일관성을 항상 보장하지 않으므로 `mysqldump`를 대체하지 않는다.
+
+### 12.3 S3 미디어
+
+미디어 버킷은 버전 관리가 켜져 있고, 삭제·덮어쓰기된 객체의 비현재 버전은 기본 약 30일 뒤 만료된다. 이 기간은 실수 복구 창이지 장기 백업이 아니다. 현재 객체는 이 비현재 버전 lifecycle의 만료 대상이 아니다.
+
+```powershell
+$Bucket = terraform -chdir=infra/aws-ec2 output -raw media_bucket_name
+aws s3api list-object-versions --bucket $Bucket --prefix "media/<object-key>"
+```
+
+필요한 version을 같은 key의 새 현재 버전으로 복사할 수 있다. 다만 DB 레코드까지 삭제됐다면 S3 객체만 복원해도 화면에 다시 나타나지 않으므로 DB 복구와 함께 처리한다.
+
+## 13. 완전 삭제
+
+`stop`은 비용을 완전히 없애지 않는다. 포트폴리오 실습을 끝냈다면 다음 순서로 삭제한다.
+
+1. 필요한 DB dump, S3 미디어, 배포 digest, Terraform state를 백업한다.
+2. 수동 EBS snapshot이 있으면 보존 또는 삭제를 결정한다.
+3. Terraform 디렉터리에서 `terraform plan -destroy`를 검토한다.
+4. 배포 버킷을 비운다.
+5. 미디어 버킷의 **현재 객체, 모든 version, delete marker**를 비운다.
+6. `terraform destroy`를 실행한다.
+7. Billing과 Resource Explorer에서 EC2, EBS volume·snapshot, S3, Public IPv4, Budget 잔여 항목을 확인한다.
+
+```powershell
+Set-Location infra\aws-ec2
+terraform plan -destroy
+
+$DeployBucket = terraform output -raw deployment_bucket_name
+aws s3 rm "s3://$DeployBucket" --recursive
+```
+
+버전 관리 버킷에서 `aws s3 rm --recursive`만 실행하면 이전 version과 delete marker가 남는다. 미디어 버킷은 AWS S3 콘솔의 **Empty** 기능으로 모든 version을 포함해 비우거나, 검증된 version-aware 삭제 스크립트를 사용한다. 버킷 이름과 계정을 두 번 확인한다.
+
+```powershell
+terraform destroy
+```
+
+`media_bucket_force_destroy = true`로 우회하면 실수 한 번에 미디어 version까지 삭제될 수 있으므로 기본값을 유지한다. Terraform이 이 계정의 GitHub OIDC provider까지 최초 생성했다면 destroy가 그 provider도 삭제한다. 다른 저장소가 공유해야 한다면 처음부터 `github_oidc_provider_arn`으로 기존 provider를 참조해 수명 주기를 분리한다.
+
+루트 EBS는 인스턴스 종료 시 삭제된다. 수동 snapshot, Terraform이 관리하지 않는 객체, GHCR package, DNS는 별도로 확인해야 한다.
+
+## 14. 보안·운영 체크리스트
+
+- [ ] `terraform apply` 전 AWS Account ID, 리전, plan과 예상 비용을 검토했다.
+- [ ] Free Tier 종료일과 남은 Credits를 확인했다.
+- [ ] Budget 이메일 알림을 설정하고 수신 여부를 확인했다.
+- [ ] GitHub `production`에 `main` 제한과 required reviewer가 있다.
+- [ ] GitHub와 Kubernetes 어디에도 장기 AWS access key가 없다.
+- [ ] 배포 입력은 tag가 아니라 검증된 `@sha256:` digest다.
+- [ ] GHCR 이미지는 `linux/arm64`를 포함한다.
+- [ ] SSH 22, MySQL 3306, Redis 6379, 백엔드 8080이 공개되지 않았다.
+- [ ] 미디어·배포 S3 Public Access Block과 TLS deny policy가 유지된다.
+- [ ] 배포 뒤 rollout, readiness, 외부 API, 채팅, 다중 미디어 시나리오를 확인했다.
+- [ ] EC2를 다시 시작한 뒤 새 동적 IP로 재배포했다.
+- [ ] 중요한 DB 데이터의 논리 백업과 실제 복구 시험이 있다.
+- [ ] HTTP 데모에는 실제 사용자 자격 증명이나 민감 정보를 넣지 않는다.
+- [ ] 사용하지 않을 때 EC2를 중지하고, 실습 종료 후 EBS·S3·snapshot까지 삭제 확인한다.
+
+## 15. 이 구성을 확장해야 하는 기준
+
+다음 중 하나가 필요해지면 단일 노드 포트폴리오 구성을 그대로 운영하지 않는다.
+
+- 실제 사용자 계정과 민감한 채팅을 상시 처리한다.
+- 노드 장애에도 서비스를 유지해야 한다.
+- DB의 자동 백업, 시점 복구, 장애 조치가 필요하다.
+- 동영상 변환 작업이 API 요청과 자원을 경쟁한다.
+- 여러 백엔드 replica와 분산 WebSocket·스케줄러 조정이 필요하다.
+- 안정된 도메인, TLS, CDN, WAF, 관찰성이 필요하다.
+
+그때의 우선순위는 보통 **TLS·고정 주소 → 자동 DB 백업 또는 RDS → 비동기 미디어 worker → CloudFront → 다중 노드/관리형 Kubernetes 검토**다. EKS는 제어부와 워커 비용, 운영 복잡도를 모두 계산한 뒤 선택한다.

--- a/infra/aws-ec2/.terraform.lock.hcl
+++ b/infra/aws-ec2/.terraform.lock.hcl
@@ -1,0 +1,49 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:aP+NgJDq4zK2Syc9rE+lfDL3jNztwN9r4BxS9+VFuIQ=",
+    "h1:pdl5u/cxTU5ctqlHFr/Z4IPPVIDX9Gt+wBQbzZjLWlM=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/aws-ec2/main.tf
+++ b/infra/aws-ec2/main.tf
@@ -1,0 +1,722 @@
+data "aws_partition" "current" {}
+
+data "aws_ssm_parameter" "ubuntu_arm64_ami" {
+  name = "/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"
+}
+
+locals {
+  instance_name       = "${var.project_name}-k3s"
+  ubuntu_arm64_ami_id = nonsensitive(data.aws_ssm_parameter.ubuntu_arm64_ami.value)
+  media_prefix        = "media/"
+  deployment_prefix   = "deployments/"
+  k3s_version_url     = replace(var.k3s_version, "+", "%2B")
+
+  github_oidc_provider_arn = coalesce(
+    var.github_oidc_provider_arn,
+    try(aws_iam_openid_connect_provider.github[0].arn, null)
+  )
+
+  k3s_user_data = <<-USER_DATA
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+    exec > >(tee -a /var/log/talk-with-neighbors-bootstrap.log) 2>&1
+    export DEBIAN_FRONTEND=noninteractive
+
+    # A small swap file helps the 2 GiB portfolio node tolerate short memory
+    # spikes. k3s is explicitly configured not to reject a swap-enabled host.
+    if [[ ! -f /swapfile ]]; then
+      fallocate -l 2G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=2048 status=progress
+    fi
+    chmod 0600 /swapfile
+    if [[ "$(blkid -s TYPE -o value /swapfile 2>/dev/null || true)" != "swap" ]]; then
+      mkswap /swapfile
+    fi
+    if ! swapon --show=NAME --noheadings | grep -Eq '^[[:space:]]*/swapfile[[:space:]]*$'; then
+      swapon /swapfile
+    fi
+    if ! grep -Eq '^/swapfile[[:space:]]' /etc/fstab; then
+      printf '/swapfile none swap sw 0 0\n' >> /etc/fstab
+    fi
+    printf 'vm.swappiness=10\n' > /etc/sysctl.d/99-talk-with-neighbors-swap.conf
+    sysctl -w vm.swappiness=10
+
+    apt-get update -y
+    apt-get install -y ca-certificates curl jq unzip
+
+    if systemctl list-unit-files --no-legend | awk '{print $1}' | grep -Fxq amazon-ssm-agent.service; then
+      systemctl enable --now amazon-ssm-agent.service
+      ssm_service=amazon-ssm-agent.service
+    elif systemctl list-unit-files --no-legend | awk '{print $1}' | grep -Fxq snap.amazon-ssm-agent.amazon-ssm-agent.service; then
+      snap start --enable amazon-ssm-agent
+      ssm_service=snap.amazon-ssm-agent.amazon-ssm-agent.service
+    elif command -v snap >/dev/null 2>&1; then
+      if ! snap list amazon-ssm-agent >/dev/null 2>&1; then
+        snap install amazon-ssm-agent --classic
+      fi
+      snap start --enable amazon-ssm-agent
+      ssm_service=snap.amazon-ssm-agent.amazon-ssm-agent.service
+    else
+      echo 'Amazon SSM Agent is unavailable' >&2
+      exit 1
+    fi
+    systemctl is-active --quiet "$ssm_service"
+
+    if ! command -v aws >/dev/null 2>&1; then
+      aws_cli_dir="$(mktemp -d)"
+      curl --fail --show-error --location \
+        https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${var.aws_cli_version}.zip \
+        --output "$aws_cli_dir/awscliv2.zip"
+      printf '%s  %s\n' '${var.aws_cli_aarch64_sha256}' "$aws_cli_dir/awscliv2.zip" | sha256sum --check --status
+      unzip -q "$aws_cli_dir/awscliv2.zip" -d "$aws_cli_dir"
+      "$aws_cli_dir/aws/install" --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli
+      rm -rf -- "$aws_cli_dir"
+    fi
+
+    install -d -m 0755 /etc/rancher/k3s
+    cat > /etc/rancher/k3s/config.yaml <<'K3S_CONFIG'
+    write-kubeconfig-mode: "0640"
+    secrets-encryption: true
+    kubelet-arg:
+      - "fail-swap-on=false"
+    K3S_CONFIG
+
+    curl --fail --show-error --location \
+      https://raw.githubusercontent.com/k3s-io/k3s/${local.k3s_version_url}/install.sh \
+      --output /tmp/install-k3s.sh
+    printf '%s  %s\n' '${var.k3s_install_script_sha256}' /tmp/install-k3s.sh | sha256sum --check --status
+    chmod 0700 /tmp/install-k3s.sh
+    INSTALL_K3S_VERSION='${var.k3s_version}' /tmp/install-k3s.sh
+    rm -f -- /tmp/install-k3s.sh
+    systemctl enable --now k3s
+
+    node_ready=false
+    for attempt in $(seq 1 60); do
+      if /usr/local/bin/k3s kubectl wait --for=condition=Ready node --all --timeout=10s >/dev/null 2>&1; then
+        node_ready=true
+        break
+      fi
+      sleep 5
+    done
+    if [[ "$node_ready" != true ]]; then
+      journalctl --unit k3s --no-pager --lines 200
+      exit 1
+    fi
+
+    install -d -m 0700 /var/lib/talk-with-neighbors/release
+    touch /var/lib/rancher/k3s/server/node-ready
+  USER_DATA
+}
+
+resource "random_id" "media_bucket_suffix" {
+  byte_length = 6
+
+  keepers = {
+    project_name = var.project_name
+  }
+}
+
+resource "random_id" "deployment_bucket_suffix" {
+  byte_length = 6
+
+  keepers = {
+    project_name = var.project_name
+  }
+}
+
+resource "aws_vpc" "app" {
+  cidr_block                       = var.vpc_cidr
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block = false
+  instance_tenancy                 = "default"
+
+  tags = {
+    Name      = "${var.project_name}-vpc"
+    Component = "network"
+  }
+}
+
+resource "aws_internet_gateway" "app" {
+  vpc_id = aws_vpc.app.id
+
+  tags = {
+    Name      = "${var.project_name}-igw"
+    Component = "network"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.app.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name      = "${var.project_name}-public"
+    Component = "network"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = startswith(var.availability_zone, var.aws_region)
+      error_message = "availability_zone must belong to aws_region."
+    }
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.app.id
+
+  tags = {
+    Name      = "${var.project_name}-public"
+    Component = "network"
+  }
+}
+
+resource "aws_route" "internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.app.id
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Gateway endpoints have no hourly endpoint charge and keep EC2-to-S3 traffic
+# off the public internet without requiring a NAT gateway.
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.app.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.public.id]
+
+  tags = {
+    Name      = "${var.project_name}-s3"
+    Component = "network"
+  }
+}
+
+resource "aws_security_group" "app" {
+  name                   = "${var.project_name}-web"
+  description            = "Public HTTP and HTTPS only; administration uses SSM"
+  vpc_id                 = aws_vpc.app.id
+  revoke_rules_on_delete = true
+
+  tags = {
+    Name      = "${var.project_name}-web"
+    Component = "k3s-node"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.app.id
+  description       = "Public HTTP"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.app.id
+  description       = "Public HTTPS"
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_ipv4" {
+  security_group_id = aws_security_group.app.id
+  description       = "Package, image, AWS API, and SSM access"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+resource "aws_s3_bucket" "media" {
+  bucket        = "${var.project_name}-media-${random_id.media_bucket_suffix.hex}"
+  force_destroy = var.media_bucket_force_destroy
+
+  tags = {
+    Name      = "${var.project_name}-media"
+    Component = "media-storage"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Versioning protects against accidental deletion, while bounded retention keeps
+# old media versions from accumulating indefinitely in this low-cost portfolio.
+resource "aws_s3_bucket_lifecycle_configuration" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  rule {
+    id     = "expire-noncurrent-media"
+    status = "Enabled"
+
+    filter {
+      prefix = local.media_prefix
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.media_noncurrent_version_expiration_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  rule {
+    id     = "remove-expired-delete-markers"
+    status = "Enabled"
+
+    filter {
+      prefix = local.media_prefix
+    }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.media]
+}
+
+resource "aws_s3_bucket" "deployment" {
+  bucket        = "${var.project_name}-deploy-${random_id.deployment_bucket_suffix.hex}"
+  force_destroy = false
+
+  tags = {
+    Name      = "${var.project_name}-deployments"
+    Component = "deployment"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "deployment" {
+  bucket = aws_s3_bucket.deployment.id
+
+  rule {
+    id     = "expire-deployment-bundles"
+    status = "Enabled"
+
+    filter {
+      prefix = local.deployment_prefix
+    }
+
+    expiration {
+      days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "deployment" {
+  bucket = aws_s3_bucket.deployment.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "deployment" {
+  bucket = aws_s3_bucket.deployment.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "deployment" {
+  bucket = aws_s3_bucket.deployment.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "media_bucket_tls" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.media.arn,
+      "${aws_s3_bucket.media.arn}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "media_tls" {
+  bucket = aws_s3_bucket.media.id
+  policy = data.aws_iam_policy_document.media_bucket_tls.json
+}
+
+data "aws_iam_policy_document" "deployment_bucket_tls" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.deployment.arn,
+      "${aws_s3_bucket.deployment.arn}/*"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "deployment_tls" {
+  bucket = aws_s3_bucket.deployment.id
+  policy = data.aws_iam_policy_document.deployment_bucket_tls.json
+}
+
+resource "aws_budgets_budget" "monthly" {
+  count = var.budget_alert_email == null ? 0 : 1
+
+  name         = "${var.project_name}-monthly-cost"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    notification_type          = "ACTUAL"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    subscriber_email_addresses = compact([var.budget_alert_email])
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    notification_type          = "FORECASTED"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    subscriber_email_addresses = compact([var.budget_alert_email])
+  }
+}
+
+data "aws_iam_policy_document" "instance_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name               = "${var.project_name}-ec2"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role.json
+
+  tags = {
+    Component = "k3s-node"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "instance_s3" {
+  statement {
+    sid       = "ReadBucketLocations"
+    actions   = ["s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.media.arn, aws_s3_bucket.deployment.arn]
+  }
+
+  statement {
+    sid       = "CheckDedicatedMediaBucket"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.media.arn]
+  }
+
+  statement {
+    sid = "ManageMediaObjects"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject"
+    ]
+    resources = ["${aws_s3_bucket.media.arn}/${local.media_prefix}*"]
+  }
+
+  statement {
+    sid       = "ListDeploymentPrefix"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.deployment.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["deployments", "deployments/*"]
+    }
+  }
+
+  statement {
+    sid = "ReadDeploymentBundles"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = ["${aws_s3_bucket.deployment.arn}/${local.deployment_prefix}*"]
+  }
+}
+
+resource "aws_iam_role_policy" "instance_s3" {
+  name   = "s3-media-and-deployments"
+  role   = aws_iam_role.instance.id
+  policy = data.aws_iam_policy_document.instance_s3.json
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name = "${var.project_name}-ec2"
+  role = aws_iam_role.instance.name
+}
+
+resource "aws_instance" "app" {
+  ami                         = local.ubuntu_arm64_ami_id
+  instance_type               = var.instance_type
+  availability_zone           = var.availability_zone
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.app.id]
+  associate_public_ip_address = true
+  iam_instance_profile        = aws_iam_instance_profile.app.name
+  monitoring                  = false
+  source_dest_check           = true
+  user_data                   = local.k3s_user_data
+  user_data_replace_on_change = false
+
+  dynamic "credit_specification" {
+    for_each = startswith(var.instance_type, "t4g.") ? [1] : []
+
+    content {
+      cpu_credits = "standard"
+    }
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
+    http_put_response_hop_limit = 2
+    http_tokens                 = "required"
+    instance_metadata_tags      = "disabled"
+  }
+
+  root_block_device {
+    delete_on_termination = true
+    encrypted             = true
+    volume_size           = var.root_volume_size_gib
+    volume_type           = "gp3"
+
+    tags = {
+      Name      = "${var.project_name}-root"
+      Component = "k3s-node"
+    }
+  }
+
+  tags = {
+    Name      = local.instance_name
+    Component = "k3s-node"
+  }
+
+  # MySQL and Redis currently persist on this instance's root EBS volume.
+  # Canonical's "current" AMI and bootstrap edits must not silently replace it.
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+
+  depends_on = [
+    aws_iam_role_policy.instance_s3,
+    aws_iam_role_policy_attachment.ssm_core,
+    aws_route_table_association.public,
+    aws_vpc_security_group_egress_rule.all_ipv4
+  ]
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.github_oidc_provider_arn == null ? 1 : 0
+
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = {
+    Name      = "github-actions"
+    Component = "deployment"
+  }
+}
+
+data "aws_iam_policy_document" "github_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_owner}/${var.github_repository}:environment:${var.github_environment}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy" {
+  name                 = "${var.project_name}-github-deploy"
+  assume_role_policy   = data.aws_iam_policy_document.github_assume_role.json
+  max_session_duration = 3600
+
+  tags = {
+    Component = "deployment"
+  }
+}
+
+data "aws_iam_policy_document" "github_deploy" {
+  statement {
+    sid       = "ReadDeploymentBucketLocation"
+    actions   = ["s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.deployment.arn]
+  }
+
+  statement {
+    sid       = "ListDeploymentPrefix"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.deployment.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["deployments", "deployments/*"]
+    }
+  }
+
+  statement {
+    sid = "UploadAndDeleteDeploymentBundles"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject"
+    ]
+    resources = ["${aws_s3_bucket.deployment.arn}/${local.deployment_prefix}*"]
+  }
+
+  statement {
+    sid     = "RunDeploymentOnTheNode"
+    actions = ["ssm:SendCommand"]
+    resources = [
+      aws_instance.app.arn,
+      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}::document/AWS-RunShellScript"
+    ]
+  }
+
+  statement {
+    sid = "MonitorOrCancelDeployment"
+    actions = [
+      "ssm:CancelCommand",
+      "ssm:DescribeInstanceInformation",
+      "ssm:GetCommandInvocation"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "StartAndStopTheNode"
+    actions = [
+      "ec2:StartInstances",
+      "ec2:StopInstances"
+    ]
+    resources = [aws_instance.app.arn]
+  }
+
+  statement {
+    sid       = "ReadNodeState"
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_deploy" {
+  name   = "ec2-k3s-deploy"
+  role   = aws_iam_role.github_deploy.id
+  policy = data.aws_iam_policy_document.github_deploy.json
+}

--- a/infra/aws-ec2/outputs.tf
+++ b/infra/aws-ec2/outputs.tf
@@ -1,0 +1,54 @@
+output "instance_id" {
+  description = "EC2 instance ID used by the SSM deployment workflow."
+  value       = aws_instance.app.id
+}
+
+output "instance_public_ip" {
+  description = "Current dynamic public IPv4 address. It can change after stop/start because no Elastic IP is allocated."
+  value       = aws_instance.app.public_ip
+}
+
+output "application_http_url" {
+  description = "Current HTTP origin for initial smoke tests. Configure DNS and TLS before real production use."
+  value       = "http://${aws_instance.app.public_ip}"
+}
+
+output "ubuntu_arm64_ami_id" {
+  description = "Ubuntu 24.04 ARM64 AMI resolved from Canonical's public SSM parameter."
+  value       = local.ubuntu_arm64_ami_id
+}
+
+output "media_bucket_name" {
+  description = "Private, versioned S3 bucket used for application media."
+  value       = aws_s3_bucket.media.id
+}
+
+output "media_prefix" {
+  description = "Object prefix granted to the application instance role."
+  value       = local.media_prefix
+}
+
+output "deployment_bucket_name" {
+  description = "Private, unversioned S3 bucket used for short-lived deployment bundles."
+  value       = aws_s3_bucket.deployment.id
+}
+
+output "deployment_prefix" {
+  description = "Deployment bundle prefix that expires after one day."
+  value       = local.deployment_prefix
+}
+
+output "github_deploy_role_arn" {
+  description = "Set this as the AWS_DEPLOY_ROLE_ARN GitHub Actions environment variable."
+  value       = aws_iam_role.github_deploy.arn
+}
+
+output "instance_role_arn" {
+  description = "EC2 role inherited by k3s pods through IMDSv2 for scoped S3 access."
+  value       = aws_iam_role.instance.arn
+}
+
+output "monthly_budget_name" {
+  description = "AWS Budgets name when budget_alert_email is configured; otherwise null."
+  value       = try(aws_budgets_budget.monthly[0].name, null)
+}

--- a/infra/aws-ec2/terraform.tfvars.example
+++ b/infra/aws-ec2/terraform.tfvars.example
@@ -1,0 +1,24 @@
+# Seoul defaults. Change both values together if deploying to another region.
+aws_region        = "ap-northeast-2"
+availability_zone = "ap-northeast-2a"
+
+# ARM64 only. t4g.small is the low-cost 2 GiB portfolio default.
+instance_type              = "t4g.small"
+root_volume_size_gib       = 30
+k3s_version                = "v1.34.8+k3s1"
+k3s_install_script_sha256  = "40b487f0d8ef4f5d1bf422e7bb6228cc7789c40ecc66c5ab067d396bbee9816e"
+aws_cli_version             = "2.35.22"
+aws_cli_aarch64_sha256      = "022e392e079ada523be29cdbb45061a74be6344179f8fddf2b8183f1898683f1"
+media_bucket_force_destroy = false
+media_noncurrent_version_expiration_days = 30
+
+github_owner       = "gitUserKHS"
+github_repository  = "talk_with_neighbors_back"
+github_environment = "production"
+
+# Set this when the AWS account already has the GitHub Actions OIDC provider.
+# github_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+
+# Optional. When set, Terraform creates a $10/month budget with email alerts.
+# budget_alert_email = "you@example.com"
+monthly_budget_usd = 10

--- a/infra/aws-ec2/tests/defaults.tftest.hcl
+++ b/infra/aws-ec2/tests/defaults.tftest.hcl
@@ -1,0 +1,98 @@
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "ami-0123456789abcdef0"
+    }
+  }
+
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+}
+
+run "secure_low_cost_defaults" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.app.instance_type == "t4g.small"
+    error_message = "The default node must remain the low-cost t4g.small ARM instance."
+  }
+
+  assert {
+    condition     = aws_instance.app.user_data_replace_on_change == false
+    error_message = "Bootstrap edits must not replace the stateful single-node instance."
+  }
+
+  assert {
+    condition = (
+      strcontains(aws_instance.app.user_data, var.aws_cli_aarch64_sha256) &&
+      strcontains(aws_instance.app.user_data, var.k3s_install_script_sha256)
+    )
+    error_message = "Root bootstrap downloads must remain pinned by SHA-256."
+  }
+
+  assert {
+    condition = (
+      aws_instance.app.metadata_options[0].http_tokens == "required" &&
+      aws_instance.app.metadata_options[0].http_put_response_hop_limit == 2
+    )
+    error_message = "The k3s node must require IMDSv2 and permit the container hop."
+  }
+
+  assert {
+    condition = (
+      aws_vpc_security_group_ingress_rule.http.from_port == 80 &&
+      aws_vpc_security_group_ingress_rule.http.to_port == 80 &&
+      aws_vpc_security_group_ingress_rule.https.from_port == 443 &&
+      aws_vpc_security_group_ingress_rule.https.to_port == 443
+    )
+    error_message = "Only the declared HTTP and HTTPS ingress rules should be public."
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.s3.vpc_endpoint_type == "Gateway"
+    error_message = "S3 access must use the no-hourly-charge Gateway endpoint."
+  }
+
+  assert {
+    condition = (
+      aws_s3_bucket.media.force_destroy == false &&
+      aws_s3_bucket.deployment.force_destroy == false &&
+      aws_s3_bucket_versioning.media.versioning_configuration[0].status == "Enabled" &&
+      one([
+        for rule in aws_s3_bucket_lifecycle_configuration.media.rule :
+        rule.noncurrent_version_expiration[0].noncurrent_days
+        if rule.id == "expire-noncurrent-media"
+      ]) == 30
+    )
+    error_message = "Buckets must be deletion-protected, media versioning enabled, and old media versions bounded by default."
+  }
+
+  assert {
+    condition     = length(aws_budgets_budget.monthly) == 0
+    error_message = "The optional budget must not block deployments when no alert email is supplied."
+  }
+}
+
+run "budget_email_opt_in" {
+  command = plan
+
+  variables {
+    budget_alert_email = "portfolio-owner@example.com"
+  }
+
+  assert {
+    condition     = length(aws_budgets_budget.monthly) == 1
+    error_message = "Supplying a budget email must create one monthly cost budget."
+  }
+}

--- a/infra/aws-ec2/variables.tf
+++ b/infra/aws-ec2/variables.tf
@@ -1,0 +1,202 @@
+variable "project_name" {
+  description = "Lowercase prefix used for AWS resource names and tags."
+  type        = string
+  default     = "talk-with-neighbors"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]{1,28}[a-z0-9])$", var.project_name))
+    error_message = "project_name must be 3-30 lowercase letters, digits, or hyphens and cannot start or end with a hyphen."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for the single-node deployment."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "availability_zone" {
+  description = "Availability Zone for the public subnet and EC2 instance."
+  type        = string
+  default     = "ap-northeast-2a"
+}
+
+variable "vpc_cidr" {
+  description = "IPv4 CIDR for the dedicated low-cost VPC."
+  type        = string
+  default     = "10.42.0.0/16"
+
+  validation {
+    condition     = can(cidrnetmask(var.vpc_cidr))
+    error_message = "vpc_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "public_subnet_cidr" {
+  description = "IPv4 CIDR for the single public subnet. It must be contained by vpc_cidr."
+  type        = string
+  default     = "10.42.1.0/24"
+
+  validation {
+    condition     = can(cidrnetmask(var.public_subnet_cidr))
+    error_message = "public_subnet_cidr must be a valid IPv4 CIDR."
+  }
+}
+
+variable "instance_type" {
+  description = "ARM64 EC2 type. t4g.small is the default low-cost choice and may be eligible for new-account AWS Free Tier credits; verify the account's billing offer."
+  type        = string
+  default     = "t4g.small"
+
+  validation {
+    condition = can(regex(
+      "^(t4g|a1|c6g|c6gd|c6gn|c7g|c7gd|c7gn|c8g|m6g|m6gd|m7g|m7gd|m8g|r6g|r6gd|r7g|r7gd|r8g)[.][a-z0-9]+$",
+      var.instance_type
+    ))
+    error_message = "instance_type must be an ARM64/Graviton EC2 type compatible with the Ubuntu ARM64 AMI."
+  }
+}
+
+variable "root_volume_size_gib" {
+  description = "Encrypted gp3 root volume size in GiB. 30 GiB is a practical minimum for k3s images, logs, and the local database."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.root_volume_size_gib >= 20 && var.root_volume_size_gib <= 16384 && floor(var.root_volume_size_gib) == var.root_volume_size_gib
+    error_message = "root_volume_size_gib must be a whole number between 20 and 16384."
+  }
+}
+
+variable "k3s_version" {
+  description = "Pinned k3s release installed during first boot."
+  type        = string
+  default     = "v1.34.8+k3s1"
+
+  validation {
+    condition     = can(regex("^v[0-9]+[.][0-9]+[.][0-9]+[+]k3s[0-9]+$", var.k3s_version))
+    error_message = "k3s_version must look like v1.34.8+k3s1."
+  }
+}
+
+variable "k3s_install_script_sha256" {
+  description = "SHA-256 of install.sh from the pinned k3s_version Git tag. Update both values together."
+  type        = string
+  default     = "40b487f0d8ef4f5d1bf422e7bb6228cc7789c40ecc66c5ab067d396bbee9816e"
+
+  validation {
+    condition     = can(regex("^[a-f0-9]{64}$", var.k3s_install_script_sha256))
+    error_message = "k3s_install_script_sha256 must be a lowercase 64-character SHA-256 digest."
+  }
+}
+
+variable "aws_cli_version" {
+  description = "Pinned AWS CLI v2 release installed on the ARM64 node."
+  type        = string
+  default     = "2.35.22"
+
+  validation {
+    condition     = can(regex("^2[.][0-9]+[.][0-9]+$", var.aws_cli_version))
+    error_message = "aws_cli_version must be an AWS CLI v2 semantic version such as 2.35.22."
+  }
+}
+
+variable "aws_cli_aarch64_sha256" {
+  description = "SHA-256 of the pinned AWS CLI v2 Linux aarch64 zip archive."
+  type        = string
+  default     = "022e392e079ada523be29cdbb45061a74be6344179f8fddf2b8183f1898683f1"
+
+  validation {
+    condition     = can(regex("^[a-f0-9]{64}$", var.aws_cli_aarch64_sha256))
+    error_message = "aws_cli_aarch64_sha256 must be a lowercase 64-character SHA-256 digest."
+  }
+}
+
+variable "media_bucket_force_destroy" {
+  description = "Allow Terraform to delete a non-empty media bucket. Keep false for deletion protection."
+  type        = bool
+  default     = false
+}
+
+variable "media_noncurrent_version_expiration_days" {
+  description = "Days to retain replaced or deleted media object versions before S3 expires them."
+  type        = number
+  default     = 30
+
+  validation {
+    condition = (
+      var.media_noncurrent_version_expiration_days >= 1 &&
+      var.media_noncurrent_version_expiration_days <= 36500 &&
+      floor(var.media_noncurrent_version_expiration_days) == var.media_noncurrent_version_expiration_days
+    )
+    error_message = "media_noncurrent_version_expiration_days must be a whole number between 1 and 36500."
+  }
+}
+
+variable "budget_alert_email" {
+  description = "Email address for optional AWS Budgets alerts. Leave null to skip budget creation and email confirmation."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.budget_alert_email == null || can(regex("^[^@[:space:]]+@[^@[:space:]]+[.][^@[:space:]]+$", var.budget_alert_email))
+    error_message = "budget_alert_email must be null or a plausible email address."
+  }
+}
+
+variable "monthly_budget_usd" {
+  description = "Monthly AWS cost budget in USD when budget_alert_email is set."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.monthly_budget_usd > 0
+    error_message = "monthly_budget_usd must be greater than zero."
+  }
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user that owns the deployment repository."
+  type        = string
+  default     = "gitUserKHS"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$", var.github_owner))
+    error_message = "github_owner must be a valid GitHub organization or user name."
+  }
+}
+
+variable "github_repository" {
+  description = "GitHub repository allowed to assume the deployment role."
+  type        = string
+  default     = "talk_with_neighbors_back"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_.-]+$", var.github_repository))
+    error_message = "github_repository contains unsupported characters."
+  }
+}
+
+variable "github_environment" {
+  description = "Protected GitHub Environment whose OIDC subject may assume the deployment role."
+  type        = string
+  default     = "production"
+
+  validation {
+    condition     = length(trimspace(var.github_environment)) > 0 && !strcontains(var.github_environment, ":")
+    error_message = "github_environment cannot be empty or contain a colon."
+  }
+}
+
+variable "github_oidc_provider_arn" {
+  description = "Existing GitHub Actions OIDC provider ARN. Leave null to create it in this AWS account."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.github_oidc_provider_arn == null || can(regex("^arn:[^:]+:iam::[0-9]{12}:oidc-provider/token[.]actions[.]githubusercontent[.]com$", var.github_oidc_provider_arn))
+    error_message = "github_oidc_provider_arn must be null or the ARN of the token.actions.githubusercontent.com provider."
+  }
+}

--- a/infra/aws-ec2/versions.tf
+++ b/infra/aws-ec2/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 1.8.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = "production"
+      ManagedBy   = "Terraform"
+    }
+  }
+}

--- a/src/main/java/com/talkwithneighbors/config/MediaResourceConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/MediaResourceConfig.java
@@ -1,6 +1,7 @@
 package com.talkwithneighbors.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -10,8 +11,10 @@ import org.springframework.web.servlet.resource.PathResourceResolver;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 
 @Configuration
+@ConditionalOnProperty(name = "app.media.storage-type", havingValue = "local", matchIfMissing = true)
 public class MediaResourceConfig implements WebMvcConfigurer {
     private final Path storageDirectory;
 
@@ -23,14 +26,16 @@ public class MediaResourceConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        String resourceLocation = storageDirectory.toUri().toString();
-        if (!resourceLocation.endsWith("/")) {
-            resourceLocation += "/";
+        for (String category : List.of("feed", "profile", "chat")) {
+            String resourceLocation = storageDirectory.resolve(category).toUri().toString();
+            if (!resourceLocation.endsWith("/")) {
+                resourceLocation += "/";
+            }
+            registry.addResourceHandler("/uploads/" + category + "/**")
+                    .addResourceLocations(resourceLocation)
+                    .setCacheControl(CacheControl.maxAge(Duration.ofDays(30)).cachePublic())
+                    .resourceChain(false)
+                    .addResolver(new PathResourceResolver());
         }
-        registry.addResourceHandler("/uploads/**")
-                .addResourceLocations(resourceLocation)
-                .setCacheControl(CacheControl.maxAge(Duration.ofDays(30)).cachePublic())
-                .resourceChain(false)
-                .addResolver(new PathResourceResolver());
     }
 }

--- a/src/main/java/com/talkwithneighbors/config/S3MediaStorageConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/S3MediaStorageConfig.java
@@ -1,0 +1,27 @@
+package com.talkwithneighbors.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "app.media.storage-type", havingValue = "s3")
+public class S3MediaStorageConfig {
+
+    @Bean
+    public S3Client mediaS3Client(
+            @Value("${app.media.s3.region}") String region
+    ) {
+        if (region == null || region.isBlank()) {
+            throw new IllegalStateException("app.media.s3.region is required when S3 media storage is enabled");
+        }
+        return S3Client.builder()
+                .region(Region.of(region.trim()))
+                .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                .build();
+    }
+}

--- a/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .anyRequest().permitAll()  // 모든 요청 허용
             )
             .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.ALWAYS)  // 세션을 항상 생성
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 .maximumSessions(1)  // 동시 세션 제한
                 .maxSessionsPreventsLogin(false)  // 새로운 로그인 시 이전 세션 만료
             )
@@ -37,4 +37,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-} 
+}

--- a/src/main/java/com/talkwithneighbors/config/SessionConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/SessionConfig.java
@@ -2,19 +2,24 @@ package com.talkwithneighbors.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 
 @Configuration
 public class SessionConfig {
     @Bean
-    public CookieSerializer cookieSerializer() {
+    public CookieSerializer cookieSerializer(
+            @Value("${app.session.cookie-secure:false}") boolean secure,
+            @Value("${app.session.cookie-same-site:Lax}") String sameSite,
+            @Value("${app.session.cookie-name:JSESSIONID}") String cookieName
+    ) {
         DefaultCookieSerializer serializer = new DefaultCookieSerializer();
-        serializer.setSameSite("Lax");  // AuthController와 동일하게 Lax로 설정
-        serializer.setUseSecureCookie(false);  // 개발 환경에서는 false로 설정
-        serializer.setCookieName("JSESSIONID");  // AuthController와 동일한 쿠키 이름
-        serializer.setCookiePath("/");  // 모든 경로에서 접근 가능
-        serializer.setUseHttpOnlyCookie(true);  // HttpOnly 설정
+        serializer.setSameSite(sameSite);
+        serializer.setUseSecureCookie(secure);
+        serializer.setCookieName(cookieName);
+        serializer.setCookiePath("/");
+        serializer.setUseHttpOnlyCookie(true);
         return serializer;
     }
-} 
+}

--- a/src/main/java/com/talkwithneighbors/controller/FeedController.java
+++ b/src/main/java/com/talkwithneighbors/controller/FeedController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/api/feed")
@@ -64,7 +65,11 @@ public class FeedController {
         try {
             return ResponseEntity.ok(feedService.createPost(userSession.getUserId(), request, storedMedia));
         } catch (RuntimeException exception) {
-            mediaStorageService.deletePostMedia(storedMedia.stream().map(FeedPostMedia::getUrl).toList());
+            mediaStorageService.deletePostMedia(storedMedia.stream()
+                    .flatMap(media -> Stream.of(media.getUrl(), media.getThumbnailUrl()))
+                    .filter(url -> url != null && !url.isBlank())
+                    .distinct()
+                    .toList());
             throw exception;
         }
     }

--- a/src/main/java/com/talkwithneighbors/controller/S3MediaResourceController.java
+++ b/src/main/java/com/talkwithneighbors/controller/S3MediaResourceController.java
@@ -1,0 +1,163 @@
+package com.talkwithneighbors.controller;
+
+import com.talkwithneighbors.service.media.storage.MediaObjectMetadata;
+import com.talkwithneighbors.service.media.storage.MediaObjectNotFoundException;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorageException;
+import com.talkwithneighbors.service.media.storage.MediaStoragePath;
+import com.talkwithneighbors.service.media.storage.S3MediaObjectStorage;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+import java.time.Duration;
+
+@RestController
+@ConditionalOnProperty(name = "app.media.storage-type", havingValue = "s3")
+public class S3MediaResourceController {
+
+    private static final String X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
+
+    private final S3MediaObjectStorage storage;
+
+    public S3MediaResourceController(S3MediaObjectStorage storage) {
+        this.storage = storage;
+    }
+
+    @RequestMapping(
+            path = "/uploads/{category}/{fileName:.+}",
+            method = {RequestMethod.GET, RequestMethod.HEAD}
+    )
+    public ResponseEntity<StreamingResponseBody> resource(
+            @PathVariable String category,
+            @PathVariable String fileName,
+            @RequestHeader(value = HttpHeaders.RANGE, required = false) String rangeHeader,
+            HttpServletRequest request
+    ) {
+        String relativeKey;
+        try {
+            relativeKey = MediaStoragePath.relativeKey(category, fileName);
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.notFound().build();
+        }
+
+        MediaObjectMetadata metadata;
+        try {
+            metadata = storage.metadata(relativeKey);
+        } catch (MediaObjectNotFoundException exception) {
+            return ResponseEntity.notFound().build();
+        } catch (MediaObjectStorageException exception) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Media storage is unavailable");
+        }
+
+        ByteRange range;
+        try {
+            range = ByteRange.parse(rangeHeader, metadata.contentLength());
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                    .header(HttpHeaders.CONTENT_RANGE, "bytes */" + metadata.contentLength())
+                    .build();
+        }
+
+        HttpHeaders headers = responseHeaders(metadata, range);
+        if (RequestMethod.HEAD.name().equals(request.getMethod())) {
+            return new ResponseEntity<>(null, headers, range == null ? HttpStatus.OK : HttpStatus.PARTIAL_CONTENT);
+        }
+
+        String s3Range = range == null ? null : range.asHeaderValue();
+        StreamingResponseBody body = outputStream -> storage.writeTo(relativeKey, s3Range, outputStream);
+        return new ResponseEntity<>(body, headers, range == null ? HttpStatus.OK : HttpStatus.PARTIAL_CONTENT);
+    }
+
+    private HttpHeaders responseHeaders(MediaObjectMetadata metadata, ByteRange range) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(mediaType(metadata.contentType()));
+        headers.setCacheControl(CacheControl.maxAge(Duration.ofDays(30)).cachePublic().immutable());
+        headers.set(HttpHeaders.ACCEPT_RANGES, "bytes");
+        headers.set(X_CONTENT_TYPE_OPTIONS, "nosniff");
+        if (metadata.eTag() != null && !metadata.eTag().isBlank()) {
+            String eTag = metadata.eTag().startsWith("\"")
+                    ? metadata.eTag()
+                    : "\"" + metadata.eTag() + "\"";
+            headers.setETag(eTag);
+        }
+        if (metadata.lastModified() != null) {
+            headers.setLastModified(metadata.lastModified().toEpochMilli());
+        }
+        if (range == null) {
+            headers.setContentLength(metadata.contentLength());
+        } else {
+            headers.setContentLength(range.length());
+            headers.set(HttpHeaders.CONTENT_RANGE,
+                    "bytes " + range.start() + "-" + range.end() + "/" + metadata.contentLength());
+        }
+        return headers;
+    }
+
+    private MediaType mediaType(String value) {
+        try {
+            return MediaType.parseMediaType(value);
+        } catch (IllegalArgumentException exception) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+    }
+
+    private record ByteRange(long start, long end) {
+
+        private static ByteRange parse(String header, long totalLength) {
+            if (header == null || header.isBlank()) {
+                return null;
+            }
+            String value = header.trim();
+            if (!value.regionMatches(true, 0, "bytes=", 0, 6) || value.indexOf(',') >= 0 || totalLength <= 0) {
+                throw new IllegalArgumentException("Unsupported range");
+            }
+            String specification = value.substring(6).trim();
+            int dash = specification.indexOf('-');
+            if (dash < 0 || dash != specification.lastIndexOf('-')) {
+                throw new IllegalArgumentException("Invalid range");
+            }
+            String startValue = specification.substring(0, dash).trim();
+            String endValue = specification.substring(dash + 1).trim();
+            try {
+                if (startValue.isEmpty()) {
+                    long suffixLength = Long.parseLong(endValue);
+                    if (suffixLength <= 0) {
+                        throw new IllegalArgumentException("Invalid suffix range");
+                    }
+                    long start = Math.max(0, totalLength - suffixLength);
+                    return new ByteRange(start, totalLength - 1);
+                }
+                long start = Long.parseLong(startValue);
+                if (start < 0 || start >= totalLength) {
+                    throw new IllegalArgumentException("Unsatisfiable range");
+                }
+                long end = endValue.isEmpty() ? totalLength - 1 : Long.parseLong(endValue);
+                if (end < start) {
+                    throw new IllegalArgumentException("Invalid range");
+                }
+                return new ByteRange(start, Math.min(end, totalLength - 1));
+            } catch (NumberFormatException exception) {
+                throw new IllegalArgumentException("Invalid range", exception);
+            }
+        }
+
+        private long length() {
+            return end - start + 1;
+        }
+
+        private String asHeaderValue() {
+            return "bytes=" + start + "-" + end;
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/health/MediaStorageHealthIndicator.java
+++ b/src/main/java/com/talkwithneighbors/health/MediaStorageHealthIndicator.java
@@ -1,0 +1,35 @@
+package com.talkwithneighbors.health;
+
+import com.talkwithneighbors.service.media.storage.LocalMediaObjectStorage;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorage;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MediaStorageHealthIndicator implements HealthIndicator {
+
+    private final MediaObjectStorage storage;
+
+    @Autowired
+    public MediaStorageHealthIndicator(
+            MediaObjectStorage storage
+    ) {
+        this.storage = storage;
+    }
+
+    public MediaStorageHealthIndicator(String storageDirectory) {
+        this(new LocalMediaObjectStorage(storageDirectory));
+    }
+
+    @Override
+    public Health health() {
+        try {
+            storage.checkHealth();
+            return Health.up().build();
+        } catch (RuntimeException exception) {
+            return Health.down().build();
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/MediaStorageService.java
+++ b/src/main/java/com/talkwithneighbors/service/MediaStorageService.java
@@ -12,6 +12,10 @@ import com.talkwithneighbors.service.media.MediaProcessingBusyException;
 import com.talkwithneighbors.service.media.MediaProcessingRequest;
 import com.talkwithneighbors.service.media.MediaProcessor;
 import com.talkwithneighbors.service.media.ProcessedMedia;
+import com.talkwithneighbors.service.media.storage.LocalMediaObjectStorage;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorage;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorageException;
+import com.talkwithneighbors.service.media.storage.MediaStoragePath;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,7 +49,6 @@ public class MediaStorageService {
     public static final long MAX_TOTAL_BYTES = 200L * 1024 * 1024;
     public static final long MAX_CHAT_TOTAL_BYTES = 120L * 1024 * 1024;
 
-    private static final String PUBLIC_ROOT = "/uploads/";
     private static final Set<String> ZIP_EXTENSIONS = Set.of(".zip", ".docx", ".xlsx", ".pptx");
     private static final Set<String> OLE_EXTENSIONS = Set.of(".doc", ".xls", ".ppt");
     private static final Set<String> TEXT_EXTENSIONS = Set.of(".txt", ".csv", ".json", ".md");
@@ -66,25 +69,31 @@ public class MediaStorageService {
 
     private final Path rootDirectory;
     private final Path incomingDirectory;
+    private final Path processingDirectory;
     private final MediaProcessor mediaProcessor;
+    private final MediaObjectStorage objectStorage;
 
     @Autowired
     public MediaStorageService(
             @Value("${app.media.storage-directory:./uploads}") String storageDirectory,
-            MediaProcessor mediaProcessor
+            MediaProcessor mediaProcessor,
+            MediaObjectStorage objectStorage
     ) {
         this.rootDirectory = Paths.get(storageDirectory).toAbsolutePath().normalize();
         this.incomingDirectory = rootDirectory.resolve(".incoming").normalize();
+        this.processingDirectory = incomingDirectory.resolve("processed").normalize();
         this.mediaProcessor = mediaProcessor;
-        createDirectories(rootDirectory, incomingDirectory);
+        this.objectStorage = objectStorage;
+        createDirectories(rootDirectory, incomingDirectory, processingDirectory);
+    }
+
+    public MediaStorageService(String storageDirectory, MediaProcessor mediaProcessor) {
+        this(storageDirectory, mediaProcessor, new LocalMediaObjectStorage(storageDirectory));
     }
 
     /** Lightweight constructor used by storage validation tests without requiring FFmpeg. */
     public MediaStorageService(String storageDirectory) {
-        this.rootDirectory = Paths.get(storageDirectory).toAbsolutePath().normalize();
-        this.incomingDirectory = rootDirectory.resolve(".incoming").normalize();
-        this.mediaProcessor = new PassthroughMediaProcessor();
-        createDirectories(rootDirectory, incomingDirectory);
+        this(storageDirectory, new PassthroughMediaProcessor(), new LocalMediaObjectStorage(storageDirectory));
     }
 
     public List<FeedPostMedia> storePostMedia(List<MultipartFile> files) {
@@ -144,14 +153,14 @@ public class MediaStorageService {
             return;
         }
         for (String url : urls) {
-            Path target = resolveOwnedUrl(url);
-            if (target == null) {
+            String relativeKey = MediaStoragePath.fromPublicUrl(url).orElse(null);
+            if (relativeKey == null) {
                 continue;
             }
             try {
-                Files.deleteIfExists(target);
-            } catch (IOException exception) {
-                log.warn("미디어 파일을 삭제하지 못했습니다. path={}", target, exception);
+                objectStorage.delete(relativeKey);
+            } catch (RuntimeException exception) {
+                log.warn("Could not delete owned media object. key={}", relativeKey, exception);
             }
         }
     }
@@ -169,13 +178,14 @@ public class MediaStorageService {
 
     private List<MediaAsset> storeAssets(List<MultipartFile> files, StoragePolicy policy) {
         validateRequest(files, policy);
-        Path outputDirectory = rootDirectory.resolve(policy.category()).normalize();
-        if (!outputDirectory.startsWith(rootDirectory)) {
+        Path outputDirectory = processingDirectory.resolve(policy.category()).normalize();
+        if (!outputDirectory.startsWith(processingDirectory)) {
             throw new MatchingException("안전하지 않은 미디어 경로입니다.", HttpStatus.BAD_REQUEST);
         }
         createDirectories(outputDirectory);
 
         List<Path> storedPaths = new ArrayList<>();
+        List<String> storedKeys = new ArrayList<>();
         List<MediaAsset> storedAssets = new ArrayList<>();
         try {
             for (MultipartFile file : files) {
@@ -198,13 +208,16 @@ public class MediaStorageService {
                         Path target = outputDirectory.resolve(baseName + detected.extension()).normalize();
                         Files.move(incoming, target, StandardCopyOption.REPLACE_EXISTING);
                         storedPaths.add(target);
+                        String relativeKey = relativeKey(policy.category(), target);
+                        long sizeBytes = Files.size(target);
+                        persistObject(relativeKey, target, detected.contentType(), storedKeys);
                         asset = new MediaAsset(
-                                publicUrl(policy.category(), target),
+                                MediaStoragePath.publicUrl(relativeKey),
                                 null,
                                 MediaAssetKind.FILE,
                                 detected.contentType(),
                                 originalName,
-                                Files.size(target),
+                                sizeBytes,
                                 null,
                                 null,
                                 null
@@ -224,14 +237,21 @@ public class MediaStorageService {
                         if (processed.thumbnailPath() != null) {
                             storedPaths.add(processed.thumbnailPath());
                         }
+                        String mediaKey = relativeKey(policy.category(), processed.mediaPath());
+                        String thumbnailKey = processed.thumbnailPath() == null
+                                ? null : relativeKey(policy.category(), processed.thumbnailPath());
+                        long sizeBytes = Files.size(processed.mediaPath());
+                        persistObject(mediaKey, processed.mediaPath(), processed.contentType(), storedKeys);
+                        if (processed.thumbnailPath() != null) {
+                            persistObject(thumbnailKey, processed.thumbnailPath(), "image/webp", storedKeys);
+                        }
                         asset = new MediaAsset(
-                                publicUrl(policy.category(), processed.mediaPath()),
-                                processed.thumbnailPath() == null
-                                        ? null : publicUrl(policy.category(), processed.thumbnailPath()),
+                                MediaStoragePath.publicUrl(mediaKey),
+                                thumbnailKey == null ? null : MediaStoragePath.publicUrl(thumbnailKey),
                                 detected.type(),
                                 processed.contentType(),
                                 originalName,
-                                Files.size(processed.mediaPath()),
+                                sizeBytes,
                                 processed.width(),
                                 processed.height(),
                                 processed.durationSeconds()
@@ -244,19 +264,25 @@ public class MediaStorageService {
             }
             return List.copyOf(storedAssets);
         } catch (MediaProcessingBusyException exception) {
-            deletePaths(storedPaths);
+            rollback(storedPaths, storedKeys);
             throw new MatchingException(exception.getMessage(), HttpStatus.SERVICE_UNAVAILABLE);
         } catch (MediaProcessingException exception) {
-            deletePaths(storedPaths);
+            rollback(storedPaths, storedKeys);
             throw new MatchingException(exception.getMessage(), HttpStatus.BAD_REQUEST);
+        } catch (MediaObjectStorageException exception) {
+            rollback(storedPaths, storedKeys);
+            throw new MatchingException(
+                    "미디어 파일을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.",
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
         } catch (IOException exception) {
-            deletePaths(storedPaths);
+            rollback(storedPaths, storedKeys);
             throw new MatchingException(
                     "미디어 파일을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.",
                     HttpStatus.INTERNAL_SERVER_ERROR
             );
         } catch (RuntimeException exception) {
-            deletePaths(storedPaths);
+            rollback(storedPaths, storedKeys);
             throw exception;
         }
     }
@@ -412,29 +438,8 @@ public class MediaStorageService {
         return extension.length() <= 8 ? extension : "";
     }
 
-    private String publicUrl(String category, Path path) {
-        return PUBLIC_ROOT + category + "/" + path.getFileName();
-    }
-
-    private Path resolveOwnedUrl(String url) {
-        if (url == null || !url.startsWith(PUBLIC_ROOT)) {
-            return null;
-        }
-        String relative = url.substring(PUBLIC_ROOT.length());
-        if (relative.isBlank() || relative.contains("?") || relative.contains("#")) {
-            return null;
-        }
-        Path relativePath;
-        try {
-            relativePath = Paths.get(relative).normalize();
-        } catch (RuntimeException exception) {
-            return null;
-        }
-        if (relativePath.isAbsolute() || relativePath.getNameCount() != 2) {
-            return null;
-        }
-        Path target = rootDirectory.resolve(relativePath).normalize();
-        return target.startsWith(rootDirectory) ? target : null;
+    private String relativeKey(String category, Path path) {
+        return MediaStoragePath.relativeKey(category, path.getFileName().toString());
     }
 
     private String claimedTypeOr(String claimed, String fallback) {
@@ -485,6 +490,28 @@ public class MediaStorageService {
                 Files.deleteIfExists(path);
             } catch (IOException exception) {
                 log.warn("실패한 업로드의 임시 파일을 삭제하지 못했습니다. path={}", path, exception);
+            }
+        }
+    }
+
+    private void persistObject(
+            String relativeKey,
+            Path source,
+            String contentType,
+            Collection<String> storedKeys
+    ) throws IOException {
+        objectStorage.store(relativeKey, source, contentType);
+        storedKeys.add(relativeKey);
+        Files.deleteIfExists(source);
+    }
+
+    private void rollback(Collection<Path> paths, Collection<String> storedKeys) {
+        deletePaths(paths);
+        for (String relativeKey : storedKeys) {
+            try {
+                objectStorage.delete(relativeKey);
+            } catch (RuntimeException exception) {
+                log.warn("Could not roll back media object. key={}", relativeKey, exception);
             }
         }
     }

--- a/src/main/java/com/talkwithneighbors/service/media/storage/LocalMediaObjectStorage.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/LocalMediaObjectStorage.java
@@ -1,0 +1,81 @@
+package com.talkwithneighbors.service.media.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+@Component
+@ConditionalOnProperty(name = "app.media.storage-type", havingValue = "local", matchIfMissing = true)
+public class LocalMediaObjectStorage implements MediaObjectStorage {
+
+    private static final byte[] PROBE_CONTENT = {0};
+
+    private final Path rootDirectory;
+
+    public LocalMediaObjectStorage(
+            @Value("${app.media.storage-directory:./uploads}") String storageDirectory
+    ) {
+        this.rootDirectory = Path.of(storageDirectory).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public void store(String relativeKey, Path source, String contentType) {
+        Path target = resolve(relativeKey);
+        try {
+            Files.createDirectories(target.getParent());
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException | SecurityException exception) {
+            throw new MediaObjectStorageException("Could not store local media object", exception);
+        }
+    }
+
+    @Override
+    public void delete(String relativeKey) {
+        Path target = resolve(relativeKey);
+        try {
+            Files.deleteIfExists(target);
+        } catch (IOException | SecurityException exception) {
+            throw new MediaObjectStorageException("Could not delete local media object", exception);
+        }
+    }
+
+    @Override
+    public void checkHealth() {
+        Path probeFile = null;
+        try {
+            Files.createDirectories(rootDirectory);
+            probeFile = Files.createTempFile(rootDirectory, ".readiness-", ".probe");
+            Files.write(probeFile, PROBE_CONTENT);
+            Files.delete(probeFile);
+        } catch (IOException | SecurityException exception) {
+            throw new MediaObjectStorageException("Local media storage is unavailable", exception);
+        } finally {
+            deleteProbeQuietly(probeFile);
+        }
+    }
+
+    private Path resolve(String relativeKey) {
+        String safeKey = MediaStoragePath.validateRelativeKey(relativeKey);
+        Path target = rootDirectory.resolve(safeKey.replace('/', java.io.File.separatorChar)).normalize();
+        if (!target.startsWith(rootDirectory)) {
+            throw new IllegalArgumentException("Invalid media object key");
+        }
+        return target;
+    }
+
+    private void deleteProbeQuietly(Path probeFile) {
+        if (probeFile == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(probeFile);
+        } catch (IOException | SecurityException ignored) {
+            // The original health failure is retained.
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectMetadata.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectMetadata.java
@@ -1,0 +1,11 @@
+package com.talkwithneighbors.service.media.storage;
+
+import java.time.Instant;
+
+public record MediaObjectMetadata(
+        long contentLength,
+        String contentType,
+        String eTag,
+        Instant lastModified
+) {
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectNotFoundException.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectNotFoundException.java
@@ -1,0 +1,8 @@
+package com.talkwithneighbors.service.media.storage;
+
+public class MediaObjectNotFoundException extends MediaObjectStorageException {
+
+    public MediaObjectNotFoundException() {
+        super("Media object was not found");
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectStorage.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectStorage.java
@@ -1,0 +1,16 @@
+package com.talkwithneighbors.service.media.storage;
+
+import java.nio.file.Path;
+
+/**
+ * Final storage for processed media objects. Implementations must never expose
+ * provider credentials in the public URL; callers persist only relative keys.
+ */
+public interface MediaObjectStorage {
+
+    void store(String relativeKey, Path source, String contentType);
+
+    void delete(String relativeKey);
+
+    void checkHealth();
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectStorageException.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/MediaObjectStorageException.java
@@ -1,0 +1,12 @@
+package com.talkwithneighbors.service.media.storage;
+
+public class MediaObjectStorageException extends RuntimeException {
+
+    public MediaObjectStorageException(String message) {
+        super(message);
+    }
+
+    public MediaObjectStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/MediaStoragePath.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/MediaStoragePath.java
@@ -1,0 +1,54 @@
+package com.talkwithneighbors.service.media.storage;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public final class MediaStoragePath {
+
+    public static final String PUBLIC_ROOT = "/uploads/";
+
+    private static final Set<String> CATEGORIES = Set.of("feed", "profile", "chat");
+    private static final Pattern FILE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]*");
+
+    private MediaStoragePath() {
+    }
+
+    public static String relativeKey(String category, String fileName) {
+        return validateRelativeKey(category + "/" + fileName);
+    }
+
+    public static String publicUrl(String relativeKey) {
+        return PUBLIC_ROOT + validateRelativeKey(relativeKey);
+    }
+
+    public static Optional<String> fromPublicUrl(String url) {
+        if (url == null || !url.startsWith(PUBLIC_ROOT)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(validateRelativeKey(url.substring(PUBLIC_ROOT.length())));
+        } catch (IllegalArgumentException exception) {
+            return Optional.empty();
+        }
+    }
+
+    public static String validateRelativeKey(String relativeKey) {
+        if (relativeKey == null
+                || relativeKey.isBlank()
+                || relativeKey.contains("\\")
+                || relativeKey.contains("?")
+                || relativeKey.contains("#")) {
+            throw new IllegalArgumentException("Invalid media object key");
+        }
+        String[] segments = relativeKey.split("/", -1);
+        if (segments.length != 2
+                || !CATEGORIES.contains(segments[0])
+                || !FILE_NAME.matcher(segments[1]).matches()
+                || ".".equals(segments[1])
+                || "..".equals(segments[1])) {
+            throw new IllegalArgumentException("Invalid media object key");
+        }
+        return segments[0] + "/" + segments[1];
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/media/storage/S3MediaObjectStorage.java
+++ b/src/main/java/com/talkwithneighbors/service/media/storage/S3MediaObjectStorage.java
@@ -1,0 +1,158 @@
+package com.talkwithneighbors.service.media.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+@Component
+@ConditionalOnProperty(name = "app.media.storage-type", havingValue = "s3")
+public class S3MediaObjectStorage implements MediaObjectStorage {
+
+    private static final String OBJECT_CACHE_CONTROL = "public, max-age=2592000, immutable";
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String prefix;
+
+    public S3MediaObjectStorage(
+            S3Client s3Client,
+            @Value("${app.media.s3.bucket}") String bucket,
+            @Value("${app.media.s3.prefix:media}") String prefix
+    ) {
+        if (bucket == null || bucket.isBlank()) {
+            throw new IllegalStateException("app.media.s3.bucket is required when S3 media storage is enabled");
+        }
+        this.s3Client = s3Client;
+        this.bucket = bucket.trim();
+        this.prefix = normalizePrefix(prefix);
+    }
+
+    @Override
+    public void store(String relativeKey, Path source, String contentType) {
+        String objectKey = objectKey(relativeKey);
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .contentType(safeContentType(contentType))
+                .cacheControl(OBJECT_CACHE_CONTROL)
+                .build();
+        try {
+            s3Client.putObject(request, RequestBody.fromFile(source));
+        } catch (RuntimeException exception) {
+            throw new MediaObjectStorageException("Could not store S3 media object", exception);
+        }
+    }
+
+    @Override
+    public void delete(String relativeKey) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey(relativeKey))
+                .build();
+        try {
+            s3Client.deleteObject(request);
+        } catch (RuntimeException exception) {
+            throw new MediaObjectStorageException("Could not delete S3 media object", exception);
+        }
+    }
+
+    @Override
+    public void checkHealth() {
+        try {
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+        } catch (RuntimeException exception) {
+            throw new MediaObjectStorageException("S3 media storage is unavailable", exception);
+        }
+    }
+
+    public MediaObjectMetadata metadata(String relativeKey) {
+        try {
+            HeadObjectResponse response = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey(relativeKey))
+                    .build());
+            Long contentLength = response.contentLength();
+            return new MediaObjectMetadata(
+                    contentLength == null ? 0 : contentLength,
+                    safeContentType(response.contentType()),
+                    response.eTag(),
+                    response.lastModified()
+            );
+        } catch (NoSuchKeyException exception) {
+            throw new MediaObjectNotFoundException();
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == 404) {
+                throw new MediaObjectNotFoundException();
+            }
+            throw new MediaObjectStorageException("Could not read S3 media metadata", exception);
+        } catch (RuntimeException exception) {
+            throw new MediaObjectStorageException("Could not read S3 media metadata", exception);
+        }
+    }
+
+    public void writeTo(String relativeKey, String range, OutputStream outputStream) throws IOException {
+        GetObjectRequest.Builder request = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey(relativeKey));
+        if (range != null && !range.isBlank()) {
+            request.range(range);
+        }
+        try (ResponseInputStream<?> input = s3Client.getObject(request.build())) {
+            input.transferTo(outputStream);
+        } catch (NoSuchKeyException exception) {
+            throw new MediaObjectNotFoundException();
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == 404) {
+                throw new MediaObjectNotFoundException();
+            }
+            throw new MediaObjectStorageException("Could not stream S3 media object", exception);
+        } catch (SdkException exception) {
+            throw new MediaObjectStorageException("Could not stream S3 media object", exception);
+        }
+    }
+
+    String objectKey(String relativeKey) {
+        String safeKey = MediaStoragePath.validateRelativeKey(relativeKey);
+        return prefix.isEmpty() ? safeKey : prefix + "/" + safeKey;
+    }
+
+    private String safeContentType(String contentType) {
+        return contentType == null || contentType.isBlank() ? "application/octet-stream" : contentType;
+    }
+
+    private String normalizePrefix(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String normalized = value.trim().replace('\\', '/');
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.contains("//")
+                || Arrays.stream(normalized.split("/", -1))
+                .anyMatch(segment -> segment.isBlank() || ".".equals(segment) || "..".equals(segment))) {
+            throw new IllegalArgumentException("Invalid S3 media prefix");
+        }
+        return normalized;
+    }
+}

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -1,0 +1,35 @@
+spring:
+  datasource:
+    hikari:
+      minimum-idle: ${SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE:2}
+      maximum-pool-size: ${SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE:10}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+    show-sql: ${SPRING_JPA_SHOW_SQL:false}
+    properties:
+      hibernate:
+        format_sql: false
+  session:
+    cookie:
+      secure: ${APP_SESSION_COOKIE_SECURE:false}
+
+server:
+  forward-headers-strategy: framework
+  servlet:
+    session:
+      cookie:
+        secure: ${APP_SESSION_COOKIE_SECURE:false}
+
+logging:
+  level:
+    root: ${LOGGING_LEVEL_ROOT:WARN}
+    com.talkwithneighbors: ${LOGGING_LEVEL_COM_TALKWITHNEIGHBORS:INFO}
+    org.springframework.messaging: ${LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_MESSAGING:WARN}
+    org.springframework.web.socket: ${LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_SOCKET:WARN}
+
+app:
+  media:
+    max-concurrent-processes: ${APP_MEDIA_MAX_CONCURRENT_PROCESSES:1}
+  session:
+    cookie-secure: ${APP_SESSION_COOKIE_SECURE:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,9 +94,26 @@ server:
       force-response: false
       enabled: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+      probes:
+        enabled: true
+        add-additional-paths: true
+      group:
+        liveness:
+          include: livenessState
+        readiness:
+          include: readinessState,db,redis,diskSpace,mediaStorage
+
 cors:
   allowed-origins: http://localhost:3000
-  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS
   allowed-headers: "*"
   allow-credentials: true
 
@@ -126,7 +143,12 @@ jwt:
 
 app:
   media:
+    storage-type: ${APP_MEDIA_STORAGE_TYPE:local}
     storage-directory: ${APP_MEDIA_STORAGE_DIRECTORY:./uploads}
+    s3:
+      bucket: ${APP_MEDIA_S3_BUCKET:}
+      region: ${APP_MEDIA_S3_REGION:ap-northeast-2}
+      prefix: ${APP_MEDIA_S3_PREFIX:media}
     ffmpeg-command: ${APP_MEDIA_FFMPEG_COMMAND:ffmpeg}
     ffprobe-command: ${APP_MEDIA_FFPROBE_COMMAND:ffprobe}
     processing-timeout-seconds: ${APP_MEDIA_PROCESSING_TIMEOUT_SECONDS:180}

--- a/src/test/java/com/talkwithneighbors/TalkWithNeighborsApplicationTests.java
+++ b/src/test/java/com/talkwithneighbors/TalkWithNeighborsApplicationTests.java
@@ -1,13 +1,31 @@
 package com.talkwithneighbors;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class TalkWithNeighborsApplicationTests {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Test
     void contextLoads() {
     }
 
-} 
+    @Test
+    void livenessProbeIsAvailableWithoutAuthentication() {
+        var response = restTemplate.getForEntity("/actuator/health/liveness", Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsEntry("status", "UP");
+    }
+
+}

--- a/src/test/java/com/talkwithneighbors/config/SessionConfigTest.java
+++ b/src/test/java/com/talkwithneighbors/config/SessionConfigTest.java
@@ -1,0 +1,39 @@
+package com.talkwithneighbors.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.session.web.http.CookieSerializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(SessionConfig.class);
+
+    @Test
+    void appliesOperationalCookieOverrides() {
+        contextRunner
+                .withPropertyValues(
+                        "app.session.cookie-secure=true",
+                        "app.session.cookie-same-site=Strict",
+                        "app.session.cookie-name=OPERATIONS_SESSION"
+                )
+                .run(context -> {
+                    CookieSerializer serializer = context.getBean(CookieSerializer.class);
+                    MockHttpServletResponse response = new MockHttpServletResponse();
+
+                    serializer.writeCookieValue(new CookieSerializer.CookieValue(
+                            new MockHttpServletRequest(), response, "session-value"));
+
+                    assertThat(response.getHeader(HttpHeaders.SET_COOKIE))
+                            .startsWith("OPERATIONS_SESSION=")
+                            .contains("Secure")
+                            .contains("HttpOnly")
+                            .contains("SameSite=Strict");
+                });
+    }
+}

--- a/src/test/java/com/talkwithneighbors/controller/FeedControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/FeedControllerTest.java
@@ -1,0 +1,65 @@
+package com.talkwithneighbors.controller;
+
+import com.talkwithneighbors.dto.feed.CreateFeedPostRequest;
+import com.talkwithneighbors.entity.FeedMediaType;
+import com.talkwithneighbors.entity.FeedPostMedia;
+import com.talkwithneighbors.security.UserSession;
+import com.talkwithneighbors.service.FeedService;
+import com.talkwithneighbors.service.MediaStorageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeedControllerTest {
+
+    @Mock
+    FeedService feedService;
+
+    @Mock
+    MediaStorageService mediaStorageService;
+
+    @Mock
+    MultipartFile file;
+
+    @Test
+    void removesMediaAndThumbnailWhenPostPersistenceFails() {
+        FeedPostMedia media = new FeedPostMedia(
+                "/uploads/feed/media.mp4",
+                FeedMediaType.VIDEO,
+                "/uploads/feed/media-thumbnail.webp",
+                "video/mp4",
+                10L,
+                640,
+                360,
+                1.5
+        );
+        CreateFeedPostRequest request = new CreateFeedPostRequest();
+        UserSession session = UserSession.of(7L, "user", "user@example.test", "neighbor");
+        when(mediaStorageService.storePostMedia(List.of(file))).thenReturn(List.of(media));
+        when(feedService.createPost(7L, request, List.of(media)))
+                .thenThrow(new IllegalStateException("database unavailable"));
+        FeedController controller = new FeedController(feedService, mediaStorageService);
+
+        assertThatThrownBy(() -> controller.createPostWithMedia(request, List.of(file), session))
+                .isInstanceOf(IllegalStateException.class);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> urls = ArgumentCaptor.forClass(List.class);
+        verify(mediaStorageService).deletePostMedia(urls.capture());
+        assertThat(urls.getValue()).containsExactly(
+                "/uploads/feed/media.mp4",
+                "/uploads/feed/media-thumbnail.webp"
+        );
+    }
+}

--- a/src/test/java/com/talkwithneighbors/controller/S3MediaResourceControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/S3MediaResourceControllerTest.java
@@ -1,0 +1,110 @@
+package com.talkwithneighbors.controller;
+
+import com.talkwithneighbors.service.media.storage.MediaObjectMetadata;
+import com.talkwithneighbors.service.media.storage.S3MediaObjectStorage;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.io.ByteArrayOutputStream;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3MediaResourceControllerTest {
+
+    @Mock
+    S3MediaObjectStorage storage;
+
+    @Mock
+    HttpServletRequest request;
+
+    private S3MediaResourceController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new S3MediaResourceController(storage);
+        when(storage.metadata("feed/video.mp4")).thenReturn(new MediaObjectMetadata(
+                10L, "video/mp4", "etag", Instant.parse("2026-07-14T00:00:00Z")
+        ));
+    }
+
+    @Test
+    void streamsPrivateObjectThroughStableUploadsUrl() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+        doAnswer(invocation -> {
+            invocation.<java.io.OutputStream>getArgument(2).write(new byte[] {1, 2, 3});
+            return null;
+        }).when(storage).writeTo(eq("feed/video.mp4"), eq(null), any());
+
+        var response = controller.resource("feed", "video.mp4", null, request);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        response.getBody().writeTo(output);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentLength()).isEqualTo(10);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
+        assertThat(response.getHeaders().getFirst("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(output.toByteArray()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void translatesBrowserRangeToS3Range() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+
+        var response = controller.resource("feed", "video.mp4", "bytes=2-5", request);
+        response.getBody().writeTo(new ByteArrayOutputStream());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PARTIAL_CONTENT);
+        assertThat(response.getHeaders().getContentLength()).isEqualTo(4);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes 2-5/10");
+        verify(storage).writeTo(eq("feed/video.mp4"), eq("bytes=2-5"), any());
+    }
+
+    @Test
+    void supportsSuffixRangesUsedByMediaClients() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+
+        var response = controller.resource("feed", "video.mp4", "bytes=-3", request);
+        response.getBody().writeTo(new ByteArrayOutputStream());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PARTIAL_CONTENT);
+        assertThat(response.getHeaders().getContentLength()).isEqualTo(3);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes 7-9/10");
+        verify(storage).writeTo(eq("feed/video.mp4"), eq("bytes=7-9"), any());
+    }
+
+    @Test
+    void returnsRangeNotSatisfiableWithoutFetchingObject() throws Exception {
+        var response = controller.resource("feed", "video.mp4", "bytes=20-30", request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes */10");
+        assertThat(response.getBody()).isNull();
+        verify(storage, never()).writeTo(any(), any(), any());
+    }
+
+    @Test
+    void headReturnsMetadataWithoutDownloadingObject() throws Exception {
+        when(request.getMethod()).thenReturn("HEAD");
+
+        var response = controller.resource("feed", "video.mp4", null, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentLength()).isEqualTo(10);
+        assertThat(response.getBody()).isNull();
+        verify(storage, never()).writeTo(any(), any(), any());
+    }
+}

--- a/src/test/java/com/talkwithneighbors/health/MediaStorageHealthIndicatorTest.java
+++ b/src/test/java/com/talkwithneighbors/health/MediaStorageHealthIndicatorTest.java
@@ -1,0 +1,64 @@
+package com.talkwithneighbors.health;
+
+import com.talkwithneighbors.service.media.storage.MediaObjectStorage;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorageException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.actuate.health.Status;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class MediaStorageHealthIndicatorTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void createsStorageAndCompletesWriteDeleteProbe() throws IOException {
+        Path storageDirectory = tempDirectory.resolve("uploads").resolve("media");
+        var indicator = new MediaStorageHealthIndicator(storageDirectory.toString());
+
+        var health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).isEmpty();
+        assertThat(storageDirectory).isDirectory();
+        try (var files = Files.list(storageDirectory)) {
+            assertThat(files).isEmpty();
+        }
+    }
+
+    @Test
+    void returnsDownWithoutExposingPathOrExceptionDetails() throws IOException {
+        Path regularFile = Files.writeString(tempDirectory.resolve("not-a-directory"), "occupied");
+        var indicator = new MediaStorageHealthIndicator(regularFile.toString());
+
+        var health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).isEmpty();
+        assertThat(health.toString()).doesNotContain(regularFile.toString());
+    }
+
+    @Test
+    void delegatesRemoteHealthCheckWithoutExposingProviderFailure() {
+        MediaObjectStorage storage = mock(MediaObjectStorage.class);
+        doThrow(new MediaObjectStorageException("secret bucket/provider detail"))
+                .when(storage).checkHealth();
+        var indicator = new MediaStorageHealthIndicator(storage);
+
+        var health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).isEmpty();
+        assertThat(health.toString()).doesNotContain("secret bucket/provider detail");
+        verify(storage).checkHealth();
+    }
+}

--- a/src/test/java/com/talkwithneighbors/service/MediaStorageServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/service/MediaStorageServiceTest.java
@@ -4,7 +4,9 @@ import com.talkwithneighbors.entity.FeedMediaType;
 import com.talkwithneighbors.entity.FeedPostMedia;
 import com.talkwithneighbors.entity.ChatAttachmentType;
 import com.talkwithneighbors.service.media.MediaAssetKind;
+import com.talkwithneighbors.service.media.MediaProcessor;
 import com.talkwithneighbors.service.media.ProcessedMedia;
+import com.talkwithneighbors.service.media.storage.MediaObjectStorage;
 import com.talkwithneighbors.exception.MatchingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -14,7 +16,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -119,6 +123,64 @@ class MediaStorageServiceTest {
         assertThrows(MatchingException.class, () -> service.storeProfileImage(video));
     }
 
+    @Test
+    void storesProcessedObjectsInRemoteStorageButKeepsStablePublicUrls() throws IOException {
+        RecordingObjectStorage remoteStorage = new RecordingObjectStorage();
+        MediaStorageService service = new MediaStorageService(
+                tempDirectory.toString(), processorWithThumbnail(), remoteStorage);
+
+        FeedPostMedia stored = service.storePostMedia(List.of(new MockMultipartFile(
+                "files", "photo.jpg", "image/jpeg", jpegBytes()
+        ))).get(0);
+
+        String mediaKey = stored.getUrl().substring("/uploads/".length());
+        String thumbnailKey = stored.getThumbnailUrl().substring("/uploads/".length());
+        assertTrue(stored.getUrl().startsWith("/uploads/feed/"));
+        assertTrue(remoteStorage.objects.containsKey(mediaKey));
+        assertTrue(remoteStorage.objects.containsKey(thumbnailKey));
+        try (var files = Files.walk(tempDirectory.resolve(".incoming"))) {
+            assertEquals(0, files.filter(Files::isRegularFile).count());
+        }
+    }
+
+    @Test
+    void rollsBackRemoteObjectsWhenLaterFileInSameRequestIsInvalid() {
+        RecordingObjectStorage remoteStorage = new RecordingObjectStorage();
+        MediaStorageService service = new MediaStorageService(
+                tempDirectory.toString(), processorWithThumbnail(), remoteStorage);
+        MockMultipartFile valid = new MockMultipartFile(
+                "files", "photo.jpg", "image/jpeg", jpegBytes()
+        );
+        MockMultipartFile spoofed = new MockMultipartFile(
+                "files", "not-really-video.mp4", "video/mp4", "plain text".getBytes()
+        );
+
+        assertThrows(MatchingException.class, () -> service.storePostMedia(List.of(valid, spoofed)));
+
+        assertTrue(remoteStorage.objects.isEmpty());
+        assertFalse(remoteStorage.deletedKeys.isEmpty());
+    }
+
+    @Test
+    void deletesOnlyOwnedRemoteUploadUrls() {
+        RecordingObjectStorage remoteStorage = new RecordingObjectStorage();
+        MediaStorageService service = new MediaStorageService(
+                tempDirectory.toString(), processorWithThumbnail(), remoteStorage);
+        FeedPostMedia stored = service.storePostMedia(List.of(new MockMultipartFile(
+                "files", "photo.jpg", "image/jpeg", jpegBytes()
+        ))).get(0);
+
+        service.deleteMedia(List.of(
+                stored.getUrl(),
+                stored.getThumbnailUrl(),
+                "https://example.test/remote.jpg",
+                "/uploads/feed/../secret"
+        ));
+
+        assertTrue(remoteStorage.objects.isEmpty());
+        assertEquals(2, remoteStorage.deletedKeys.size());
+    }
+
     private Path resolve(String publicUrl) {
         return tempDirectory.resolve("feed").resolve(publicUrl.substring("/uploads/feed/".length()));
     }
@@ -134,5 +196,43 @@ class MediaStorageServiceTest {
                 'i', 's', 'o', 'm',
                 0x00, 0x00, 0x00, 0x00
         };
+    }
+
+    private MediaProcessor processorWithThumbnail() {
+        return request -> {
+            String extension = request.type() == MediaAssetKind.IMAGE ? ".webp" : ".mp4";
+            Path media = request.outputDirectory().resolve(request.baseName() + extension);
+            Path thumbnail = request.outputDirectory().resolve(request.baseName() + "-thumbnail.webp");
+            Files.move(request.input(), media, StandardCopyOption.REPLACE_EXISTING);
+            Files.write(thumbnail, new byte[] {1, 2, 3});
+            return new ProcessedMedia(media, thumbnail,
+                    request.type() == MediaAssetKind.IMAGE ? "image/webp" : "video/mp4",
+                    640, 360, null);
+        };
+    }
+
+    private static final class RecordingObjectStorage implements MediaObjectStorage {
+        private final Map<String, byte[]> objects = new HashMap<>();
+        private final java.util.Set<String> deletedKeys = new java.util.HashSet<>();
+
+        @Override
+        public void store(String relativeKey, Path source, String contentType) {
+            try {
+                objects.put(relativeKey, Files.readAllBytes(source));
+            } catch (IOException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
+
+        @Override
+        public void delete(String relativeKey) {
+            deletedKeys.add(relativeKey);
+            objects.remove(relativeKey);
+        }
+
+        @Override
+        public void checkHealth() {
+            // In-memory fake is always healthy.
+        }
     }
 }

--- a/src/test/java/com/talkwithneighbors/service/media/storage/S3MediaObjectStorageTest.java
+++ b/src/test/java/com/talkwithneighbors/service/media/storage/S3MediaObjectStorageTest.java
@@ -1,0 +1,136 @@
+package com.talkwithneighbors.service.media.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3MediaObjectStorageTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Mock
+    S3Client s3Client;
+
+    private S3MediaObjectStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new S3MediaObjectStorage(s3Client, "private-media-bucket", "/neighbors/media/");
+    }
+
+    @Test
+    void storesPrivateObjectUnderConfiguredPrefixWithContentMetadata() throws Exception {
+        Path source = Files.write(tempDirectory.resolve("asset.jpg"), new byte[] {1, 2, 3});
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().eTag("etag").build());
+
+        storage.store("feed/asset.jpg", source, "image/jpeg");
+
+        ArgumentCaptor<PutObjectRequest> request = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> body = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3Client).putObject(request.capture(), body.capture());
+        assertThat(request.getValue().bucket()).isEqualTo("private-media-bucket");
+        assertThat(request.getValue().key()).isEqualTo("neighbors/media/feed/asset.jpg");
+        assertThat(request.getValue().contentType()).isEqualTo("image/jpeg");
+        assertThat(request.getValue().cacheControl()).contains("immutable");
+        assertThat(body.getValue().optionalContentLength()).contains(3L);
+    }
+
+    @Test
+    void deletesOwnedObjectAndChecksBucketHealth() {
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                .thenReturn(DeleteObjectResponse.builder().build());
+        when(s3Client.headBucket(any(HeadBucketRequest.class)))
+                .thenReturn(HeadBucketResponse.builder().build());
+
+        storage.delete("chat/file.pdf");
+        storage.checkHealth();
+
+        ArgumentCaptor<DeleteObjectRequest> delete = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(delete.capture());
+        assertThat(delete.getValue().key()).isEqualTo("neighbors/media/chat/file.pdf");
+        verify(s3Client).headBucket(HeadBucketRequest.builder().bucket("private-media-bucket").build());
+    }
+
+    @Test
+    void readsMetadataAndStreamsOnlyTheRequestedRange() throws Exception {
+        Instant modified = Instant.parse("2026-07-14T00:00:00Z");
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder()
+                .contentLength(4L)
+                .contentType("video/mp4")
+                .eTag("etag")
+                .lastModified(modified)
+                .build());
+        ResponseInputStream<GetObjectResponse> response = new ResponseInputStream<>(
+                GetObjectResponse.builder().build(),
+                AbortableInputStream.create(new ByteArrayInputStream(new byte[] {2, 3}))
+        );
+        when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(response);
+
+        MediaObjectMetadata metadata = storage.metadata("feed/video.mp4");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        storage.writeTo("feed/video.mp4", "bytes=1-2", output);
+
+        assertThat(metadata.contentLength()).isEqualTo(4);
+        assertThat(metadata.contentType()).isEqualTo("video/mp4");
+        assertThat(metadata.lastModified()).isEqualTo(modified);
+        assertThat(output.toByteArray()).containsExactly(2, 3);
+        ArgumentCaptor<GetObjectRequest> request = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(s3Client).getObject(request.capture());
+        assertThat(request.getValue().range()).isEqualTo("bytes=1-2");
+    }
+
+    @Test
+    void mapsMissingObjectToNotFoundWithoutLeakingAwsDetails() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(404).message("sensitive provider detail").build());
+
+        assertThatThrownBy(() -> storage.metadata("profile/missing.jpg"))
+                .isInstanceOf(MediaObjectNotFoundException.class)
+                .hasMessageNotContaining("sensitive provider detail");
+    }
+
+    @Test
+    void rejectsUnownedOrTraversalKeysBeforeCallingS3() {
+        assertThatThrownBy(() -> storage.delete("../secret"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> storage.delete("feed/subdirectory/file.jpg"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+}


### PR DESCRIPTION
## What changed

- add low-cost AWS EC2 + S3 infrastructure with Terraform
- deploy the stack to single-node k3s through GitHub OIDC and AWS SSM
- add private S3-backed media storage with range requests and health checks
- add multi-architecture image publishing, security scanning, infra validation, power controls, and dependency review
- document deployment, rollback, recovery, cost controls, and complete cleanup

## Why

The portfolio environment needs reproducible deployment without EKS, a load balancer, NAT Gateway, public SSH, or permanent AWS access keys. Uploaded media also needs durable object storage independent of the EC2 lifecycle.

## Impact

Local development remains on local filesystem storage. The production profile uses a private S3 bucket and deploys MySQL, Redis, backend, and frontend on a cost-conscious ARM64 EC2 instance.

## Validation

- Java 17 clean test + bootJar: 134 tests passed
- Docker Compose production configuration validated
- kustomize rendering and shell syntax validated
- Terraform formatting validated
- secret-pattern scan and git diff checks passed
- container builds, Trivy scans, Terraform tests, kubeconform, and actionlint run in GitHub Actions