### PR TITLE
Submit Gradle dependencies to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,29 @@
+name: Gradle dependency submission
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - build.gradle
+      - settings.gradle
+      - gradle/**
+      - gradlew
+      - gradlew.bat
+      - .github/workflows/dependency-submission.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Generate and submit Gradle dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6


### PR DESCRIPTION
## What changed

Adds a dedicated, SHA-pinned Gradle dependency submission workflow for the default branch.

## Why

GitHub's dependency review cannot evaluate the backend PR until the Gradle dependency graph has a resolved snapshot on `main`. Static parsing alone does not resolve the backend's transitive Gradle dependencies.

## Impact

The workflow runs when Gradle manifests or wrapper files change, and can also be started manually. It grants only the `contents: write` permission required by GitHub's dependency submission API.

## Validation

- workflow scope inspected as a single-file change
- pinned checkout, Java setup, and Gradle action revisions
- staged diff and whitespace checks passed

This is a bootstrap PR: its own dependency-review check is expected to report the missing snapshot that this workflow creates after merge.