### PR TITLE
Add protected k3s rollout diagnostics

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -30,6 +30,95 @@ permissions:
   id-token: write
 
 jobs:
+  diagnose-once:
+    name: Collect private k3s diagnostics
+    if: github.ref == 'refs/heads/agent/k3s-diagnose-once' && inputs.public_origin == 'diagnose://k3s'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      AWS_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      INSTANCE_ID: ${{ vars.EC2_INSTANCE_ID }}
+    steps:
+      - name: Configure short-lived AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-k3s-diagnostics-${{ github.run_id }}
+
+      - name: Collect diagnostics without printing application logs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$INSTANCE_ID" =~ ^i-[a-f0-9]{8,17}$ ]] || { echo "EC2_INSTANCE_ID is missing or invalid" >&2; exit 1; }
+
+          parameters_file="$(mktemp)"
+          trap 'rm -f -- "$parameters_file"' EXIT
+          diagnostic_script='set -eu
+          namespace=talk-with-neighbors
+          output=/tmp/twn-k3s-diagnostics.txt
+          {
+            date --iso-8601=seconds
+            k3s kubectl get nodes -o wide
+            k3s kubectl -n "$namespace" get pods,deployments,statefulsets,services,ingress -o wide
+            k3s kubectl -n "$namespace" get pods -o json
+            k3s kubectl -n "$namespace" describe pods -l app.kubernetes.io/name=backend
+            k3s kubectl -n "$namespace" get events --sort-by=.metadata.creationTimestamp
+            k3s kubectl -n "$namespace" logs deployment/backend --all-containers=true --tail=300 || true
+            k3s kubectl -n "$namespace" logs deployment/backend --all-containers=true --previous --tail=300 || true
+          } >"$output" 2>&1
+          gzip -9 -c "$output" | base64 -w0
+          rm -f -- "$output"'
+          jq -n --arg script "$diagnostic_script" '{commands:[$script],executionTimeout:["180"]}' > "$parameters_file"
+
+          command_id="$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --parameters "file://${parameters_file}" \
+            --timeout-seconds 60 \
+            --comment "talk-with-neighbors one-time diagnostics" \
+            --query 'Command.CommandId' \
+            --output text)"
+          echo "SSM diagnostic command: $command_id"
+
+          status=""
+          for _ in {1..60}; do
+            status="$(aws ssm get-command-invocation \
+              --command-id "$command_id" \
+              --instance-id "$INSTANCE_ID" \
+              --query Status \
+              --output text 2>/dev/null || true)"
+            case "$status" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+              Pending|InProgress|Delayed|"") sleep 5 ;;
+              *) echo "Unexpected SSM status: $status" >&2; exit 1 ;;
+            esac
+          done
+          [[ "$status" == "Success" ]] || { echo "Diagnostic SSM command ended with $status" >&2; exit 1; }
+
+          encoded="$(aws ssm get-command-invocation \
+            --command-id "$command_id" \
+            --instance-id "$INSTANCE_ID" \
+            --query StandardOutputContent \
+            --output text)"
+          [[ -n "$encoded" && "$encoded" != "None" ]] || { echo "Diagnostic output is empty" >&2; exit 1; }
+          printf '%s' "$encoded" | base64 -d | gzip -d > "$RUNNER_TEMP/k3s-diagnostics.txt"
+
+      - name: Upload private diagnostic artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: k3s-diagnostics-${{ github.run_id }}
+          path: ${{ runner.temp }}/k3s-diagnostics.txt
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Remove runner diagnostic file
+        if: always()
+        shell: bash
+        run: shred -u -- "$RUNNER_TEMP/k3s-diagnostics.txt" 2>/dev/null || rm -f -- "$RUNNER_TEMP/k3s-diagnostics.txt"
+
   deploy:
     name: Deploy through AWS Systems Manager
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -56,6 +56,8 @@ jobs:
 
           parameters_file="$(mktemp)"
           trap 'rm -f -- "$parameters_file"' EXIT
+          # Expanded later by AWS-RunShellScript on the EC2 node, not on the runner.
+          # shellcheck disable=SC2016
           diagnostic_script='set -eu
           namespace=talk-with-neighbors
           output=/tmp/twn-k3s-diagnostics.txt

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       public_origin:
-        description: "Optional HTTP origin; blank derives the EC2 IPv4; diagnose://k3s collects a private diagnostic artifact"
+        description: "Optional HTTP origin; blank derives the EC2 IPv4; diagnose://k3s collects a redacted one-day diagnostic artifact"
         required: false
         type: string
       start_if_stopped:
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   diagnose:
-    name: Collect private k3s diagnostics
+    name: Collect redacted k3s diagnostics
     if: github.ref == 'refs/heads/main' && inputs.public_origin == 'diagnose://k3s'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -59,6 +59,7 @@ jobs:
           diagnostic_script='set -eu
           namespace=talk-with-neighbors
           output=/tmp/twn-k3s-diagnostics.txt
+          redacted=/tmp/twn-k3s-diagnostics-redacted.txt
           {
             date --iso-8601=seconds
             k3s kubectl get nodes -o wide
@@ -69,8 +70,14 @@ jobs:
             k3s kubectl -n "$namespace" logs deployment/backend --all-containers=true --tail=300 || true
             k3s kubectl -n "$namespace" logs deployment/backend --all-containers=true --previous --tail=300 || true
           } >"$output" 2>&1
-          gzip -9 -c "$output" | base64 -w0
-          rm -f -- "$output"'
+          sed -E \
+            -e "/(authorization|cookie|password|secret|session([ _-]?id)?|token)/I c\\[REDACTED SENSITIVE LOG LINE]" \
+            -e "s/[[:alnum:]._%+-]+@[[:alnum:].-]+\\.[[:alpha:]]{2,}/[REDACTED_EMAIL]/g" \
+            -e "s/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/[REDACTED_UUID]/g" \
+            -e "s/eyJ[A-Za-z0-9._-]+/[REDACTED_JWT]/g" \
+            "$output" >"$redacted"
+          gzip -9 -c "$redacted" | base64 -w0
+          shred -u -- "$output" "$redacted" 2>/dev/null || rm -f -- "$output" "$redacted"'
           jq -n --arg script "$diagnostic_script" '{commands:[$script],executionTimeout:["180"]}' > "$parameters_file"
 
           command_id="$(aws ssm send-command \
@@ -106,7 +113,7 @@ jobs:
           [[ -n "$encoded" && "$encoded" != "None" ]] || { echo "Diagnostic output is empty" >&2; exit 1; }
           printf '%s' "$encoded" | base64 -d | gzip -d > "$RUNNER_TEMP/k3s-diagnostics.txt"
 
-      - name: Upload private diagnostic artifact
+      - name: Upload redacted diagnostic artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: k3s-diagnostics-${{ github.run_id }}

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       public_origin:
-        description: "Optional HTTP origin; blank derives the current EC2 public IPv4 address"
+        description: "Optional HTTP origin; blank derives the EC2 IPv4; diagnose://k3s collects a private diagnostic artifact"
         required: false
         type: string
       start_if_stopped:
@@ -30,9 +30,9 @@ permissions:
   id-token: write
 
 jobs:
-  diagnose-once:
+  diagnose:
     name: Collect private k3s diagnostics
-    if: github.ref == 'refs/heads/agent/k3s-diagnose-once' && inputs.public_origin == 'diagnose://k3s'
+    if: github.ref == 'refs/heads/main' && inputs.public_origin == 'diagnose://k3s'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: production
@@ -78,7 +78,7 @@ jobs:
             --document-name AWS-RunShellScript \
             --parameters "file://${parameters_file}" \
             --timeout-seconds 60 \
-            --comment "talk-with-neighbors one-time diagnostics" \
+            --comment "talk-with-neighbors on-demand diagnostics" \
             --query 'Command.CommandId' \
             --output text)"
           echo "SSM diagnostic command: $command_id"
@@ -121,7 +121,7 @@ jobs:
 
   deploy:
     name: Deploy through AWS Systems Manager
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && inputs.public_origin != 'diagnose://k3s'
     runs-on: ubuntu-latest
     timeout-minutes: 55
     environment: production


### PR DESCRIPTION
Adds an on-demand diagnostic mode to the existing production workflow. The production environment stays restricted to protected main, credentials remain short-lived GitHub OIDC sessions, and the SSM command is read-only. Application logs are never printed in the workflow; session/token/secret/password/email/UUID/JWT patterns are redacted before a one-day artifact is uploaded, then the runner copy is shredded. Normal deployments remain unchanged unless public_origin is exactly diagnose://k3s.