### PR TITLE
Guard the pre-destructive k3s recovery retry

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -75,6 +75,26 @@ jobs:
           encoded=/tmp/twn-k3s-diagnostics.b64
           {
             date --iso-8601=seconds
+            echo "=== migration journal metadata ==="
+            for marker in \
+              /var/lib/talk-with-neighbors/migrations/k3s-network-v1.in-progress.json \
+              /var/lib/talk-with-neighbors/migrations/k3s-network-v1.done.json \
+              /var/lib/talk-with-neighbors/migrations/mysql-restore-v1.pending.json \
+              /var/lib/talk-with-neighbors/migrations/mysql-restore-v1.done.json; do
+              marker_name="$(basename "$marker")"
+              if [ -f "$marker" ] && [ ! -L "$marker" ]; then
+                marker_phase="$(jq -r ".phase // \"n/a\"" "$marker" 2>/dev/null || echo invalid)"
+                marker_release="$(jq -r ".release_id // \"n/a\"" "$marker" 2>/dev/null || echo invalid)"
+                printf "%s owner=%s mode=%s phase=%s release=%s\n" \
+                  "$marker_name" "$(stat -c "%u" "$marker")" "$(stat -c "%a" "$marker")" \
+                  "$marker_phase" "$marker_release"
+              else
+                printf "%s missing-or-unsafe\n" "$marker_name"
+              fi
+            done
+            echo "backup-directories:"
+            find /var/lib/talk-with-neighbors/backups -mindepth 1 -maxdepth 1 -type d \
+              -name "k3s-network-v1-*" -printf "%f\n" 2>/dev/null | sort || true
             k3s kubectl get nodes -o wide
             k3s kubectl -n "$namespace" get pods,deployments,statefulsets,services,ingress -o wide
             k3s kubectl -n kube-system get pods,services -o wide

--- a/deploy/k8s/reinitialize-k3s-network.sh
+++ b/deploy/k8s/reinitialize-k3s-network.sh
@@ -33,6 +33,7 @@ readonly MYSQL_DUMP="$BACKUP_DIR/mysql.sql.gz"
 readonly LOCK_FILE="/run/lock/talk-with-neighbors-k3s-network.lock"
 
 original_backend_replicas=""
+original_backend_available=""
 original_mysql_replicas=""
 original_redis_replicas=""
 backend_scaled=false
@@ -136,6 +137,102 @@ safe_remove_cluster_state() {
   done
 }
 
+recover_stale_pre_destructive_attempt() {
+  if [[ ! -e "$IN_PROGRESS_MARKER" && ! -L "$IN_PROGRESS_MARKER" ]]; then
+    return 0
+  fi
+
+  local stale_phase stale_release stale_backup expected_backup aborted_marker file_mode artifact
+  [[ -f "$IN_PROGRESS_MARKER" && ! -L "$IN_PROGRESS_MARKER" ]] || {
+    echo "The previous migration journal is not a regular root-only file" >&2
+    return 1
+  }
+  [[ "$(readlink -e "$IN_PROGRESS_MARKER")" == "$IN_PROGRESS_MARKER" ]] || {
+    echo "The previous migration journal resolves outside its expected path" >&2
+    return 1
+  }
+  [[ "$(stat -c '%u' "$IN_PROGRESS_MARKER")" == "0" ]] || {
+    echo "The previous migration journal is not owned by root" >&2
+    return 1
+  }
+  file_mode="$(stat -c '%a' "$IN_PROGRESS_MARKER")"
+  if [[ ! "$file_mode" =~ ^[0-7]{3,4}$ ]] || (( (8#$file_mode & 077) != 0 )); then
+    echo "The previous migration journal is readable outside root" >&2
+    return 1
+  fi
+
+  stale_phase="$(jq -er '.phase | select(type == "string")' "$IN_PROGRESS_MARKER")" || {
+    echo "The previous migration journal has no valid phase" >&2
+    return 1
+  }
+  stale_release="$(jq -er '.release_id | select(type == "string" and test("^[0-9]+-[0-9]+$"))' "$IN_PROGRESS_MARKER")" || {
+    echo "The previous migration journal has no valid release id" >&2
+    return 1
+  }
+  stale_backup="$(jq -er '.backup_dir | select(type == "string")' "$IN_PROGRESS_MARKER")" || {
+    echo "The previous migration journal has no valid backup path" >&2
+    return 1
+  }
+  expected_backup="$BACKUP_ROOT/k3s-network-v1-$stale_release"
+
+  [[ "$stale_phase" == "preparing-backup" ]] || {
+    echo "The previous migration advanced beyond the safe pre-destructive retry phase: $stale_phase" >&2
+    return 1
+  }
+  [[ "$stale_backup" == "$expected_backup" && -d "$stale_backup" && ! -L "$stale_backup" ]] || {
+    echo "The previous migration backup path is unsafe" >&2
+    return 1
+  }
+  [[ "$(readlink -e "$stale_backup")" == "$stale_backup" && "$(stat -c '%u' "$stale_backup")" == "0" ]] || {
+    echo "The previous migration backup is not a root-owned canonical directory" >&2
+    return 1
+  }
+  file_mode="$(stat -c '%a' "$stale_backup")"
+  if [[ ! "$file_mode" =~ ^[0-7]{3,4}$ ]] || (( (8#$file_mode & 077) != 0 )); then
+    echo "The previous migration backup directory is accessible outside root" >&2
+    return 1
+  fi
+  [[ -s "$stale_backup/inventory.txt" && ! -L "$stale_backup/inventory.txt" ]] || {
+    echo "The previous pre-destructive inventory is missing or unsafe" >&2
+    return 1
+  }
+  file_mode="$(stat -c '%a' "$stale_backup/inventory.txt")"
+  if [[ "$(stat -c '%u' "$stale_backup/inventory.txt")" != "0" || ! "$file_mode" =~ ^[0-7]{3,4}$ ]] ||
+    (( (8#$file_mode & 077) != 0 )); then
+    echo "The previous pre-destructive inventory is accessible outside root" >&2
+    return 1
+  fi
+  if ! grep -Fxq "release_id=$stale_release" "$stale_backup/inventory.txt" ||
+    ! grep -Fxq "legacy_pod_cidr=$legacy_pod_cidr" "$stale_backup/inventory.txt" ||
+    ! grep -Fxq "backend_replicas=$original_backend_replicas" "$stale_backup/inventory.txt" ||
+    ! grep -Fxq "mysql_replicas=$original_mysql_replicas" "$stale_backup/inventory.txt" ||
+    ! grep -Fxq "redis_replicas=$original_redis_replicas" "$stale_backup/inventory.txt"; then
+    echo "Current workload replicas do not match the previous pre-destructive inventory" >&2
+    return 1
+  fi
+  if grep -q '^backend_available=' "$stale_backup/inventory.txt" &&
+    ! grep -Fxq "backend_available=$original_backend_available" "$stale_backup/inventory.txt"; then
+    echo "Current backend availability does not match the previous pre-destructive inventory" >&2
+    return 1
+  fi
+
+  for artifact in server.tar.gz mysql.sql.gz k3s-config.yaml k3s.service.env node-password SHA256SUMS; do
+    [[ ! -e "$stale_backup/$artifact" && ! -L "$stale_backup/$artifact" ]] || {
+      echo "The previous attempt created destructive-phase artifact $artifact; refusing automatic retry" >&2
+      return 1
+    }
+  done
+
+  aborted_marker="$stale_backup/aborted-before-destructive.json"
+  [[ ! -e "$aborted_marker" && ! -L "$aborted_marker" ]] || {
+    echo "The previous pre-destructive journal was already archived" >&2
+    return 1
+  }
+  chmod 0600 "$IN_PROGRESS_MARKER" || return 1
+  mv -- "$IN_PROGRESS_MARKER" "$aborted_marker" || return 1
+  echo "Archived a verified pre-destructive failed attempt at $aborted_marker"
+}
+
 restore_workload_replicas() {
   local kind name replicas
   while read -r kind name replicas; do
@@ -154,8 +251,10 @@ EOF
   done <<EOF
 statefulset mysql $original_mysql_replicas
 statefulset redis $original_redis_replicas
-deployment backend $original_backend_replicas
 EOF
+  if [[ "$original_backend_available" =~ ^[1-9][0-9]*$ && "$original_backend_replicas" =~ ^[1-9][0-9]*$ ]]; then
+    k3s kubectl -n "$NAMESPACE" rollout status deployment/backend --timeout=5m || return 1
+  fi
   backend_scaled=false
 }
 
@@ -249,7 +348,6 @@ exec 9>"$LOCK_FILE"
 flock -n 9 || die "Another k3s network migration is running"
 
 [[ ! -e "$MIGRATION_MARKER" ]] || die "The one-time k3s network migration was already completed"
-[[ ! -e "$IN_PROGRESS_MARKER" ]] || die "A previous k3s network migration is incomplete; inspect its root-only phase journal before retrying"
 [[ ! -e "$MYSQL_RESTORE_PENDING" && ! -e "$MYSQL_RESTORE_DONE" ]] || die "A MySQL restore marker already exists"
 [[ ! -e "$BACKUP_DIR" ]] || die "The release-specific backup directory already exists"
 systemctl is-active --quiet k3s || die "k3s must be active before the migration"
@@ -285,12 +383,15 @@ k3s_is_legacy_pod_cidr "$legacy_pod_cidr" || die "The current node Pod CIDR is n
 k3s kubectl -n "$NAMESPACE" get deployment/backend statefulset/mysql statefulset/redis >/dev/null
 k3s kubectl -n "$NAMESPACE" rollout status statefulset/mysql --timeout=3m
 original_backend_replicas="$(k3s kubectl -n "$NAMESPACE" get deployment/backend -o jsonpath='{.spec.replicas}')"
+original_backend_available="$(k3s kubectl -n "$NAMESPACE" get deployment/backend -o json | jq -er '.status.availableReplicas // 0')"
 original_mysql_replicas="$(k3s kubectl -n "$NAMESPACE" get statefulset/mysql -o jsonpath='{.spec.replicas}')"
 original_redis_replicas="$(k3s kubectl -n "$NAMESPACE" get statefulset/redis -o jsonpath='{.spec.replicas}')"
-for replicas in "$original_backend_replicas" "$original_mysql_replicas" "$original_redis_replicas"; do
+for replicas in "$original_backend_replicas" "$original_backend_available" "$original_mysql_replicas" "$original_redis_replicas"; do
   [[ "$replicas" =~ ^[0-9]+$ ]] || die "A workload replica count is invalid"
 done
+(( original_backend_available <= original_backend_replicas )) || die "The backend availability count exceeds its replica count"
 (( original_mysql_replicas == 1 )) || die "The migration expects one MySQL replica"
+recover_stale_pre_destructive_attempt
 
 server_size_kib="$(du -sk "$K3S_SERVER_DIR" | awk '{print $1}')"
 # MYSQL_ROOT_PASSWORD expands inside the container, not in this host shell.
@@ -306,8 +407,8 @@ required_backup_kib=$(( server_size_kib + (database_size_kib * 2) + 1048576 ))
 install -d -m 0700 "$BACKUP_DIR"
 migration_started=true
 write_phase "preparing-backup"
-printf 'release_id=%s\nlegacy_pod_cidr=%s\nbackend_replicas=%s\nmysql_replicas=%s\nredis_replicas=%s\n' \
-  "$RELEASE_ID" "$legacy_pod_cidr" "$original_backend_replicas" "$original_mysql_replicas" "$original_redis_replicas" \
+printf 'release_id=%s\nlegacy_pod_cidr=%s\nbackend_replicas=%s\nbackend_available=%s\nmysql_replicas=%s\nredis_replicas=%s\n' \
+  "$RELEASE_ID" "$legacy_pod_cidr" "$original_backend_replicas" "$original_backend_available" "$original_mysql_replicas" "$original_redis_replicas" \
   > "$BACKUP_DIR/inventory.txt"
 k3s kubectl get nodes,persistentvolumes -o yaml > "$BACKUP_DIR/cluster-inventory.yaml"
 k3s kubectl -n "$NAMESPACE" get deployments,statefulsets,persistentvolumeclaims -o yaml >> "$BACKUP_DIR/cluster-inventory.yaml"
@@ -316,7 +417,6 @@ chmod 0600 "$BACKUP_DIR"/*
 
 backend_scaled=true
 k3s kubectl -n "$NAMESPACE" scale deployment/backend --replicas=0 >/dev/null
-k3s kubectl -n "$NAMESPACE" rollout status deployment/backend --timeout=3m
 wait_for_no_pods "$NAMESPACE" 'app.kubernetes.io/name=backend' 60 || die "The backend pod did not stop before the database dump"
 write_phase "dumping-mysql"
 # MYSQL_ROOT_PASSWORD expands inside the container, not in this host shell.

--- a/deploy/k8s/tests/test-k3s-network-reinitialize.sh
+++ b/deploy/k8s/tests/test-k3s-network-reinitialize.sh
@@ -41,6 +41,12 @@ grep -Fq 'k3s-network-v1.done.json' "$SCRIPT_DIR/reinitialize-k3s-network.sh" ||
 grep -Fq 'mysql-restore-v1.pending.json' "$SCRIPT_DIR/deploy-on-node.sh" || fail "Pending MySQL restore support is missing"
 grep -Fq 'executionTimeout:["9000"]' "$SCRIPT_DIR/deploy-via-ssm.sh" || fail "The remote rollback window is too short"
 grep -Fq 'select(.conditions.ready != false)' "$SCRIPT_DIR/reinitialize-k3s-network.sh" || fail "Traefik readiness is not checked"
+grep -Fq 'recover_stale_pre_destructive_attempt' "$SCRIPT_DIR/reinitialize-k3s-network.sh" || fail "A safe pre-destructive retry path is missing"
+grep -Fq 'aborted-before-destructive.json' "$SCRIPT_DIR/reinitialize-k3s-network.sh" || fail "Failed pre-destructive journals are not retained"
+grep -Fq 'The previous migration advanced beyond the safe pre-destructive retry phase' "$SCRIPT_DIR/reinitialize-k3s-network.sh" || fail "Advanced migration phases are not blocked from automatic retry"
+if grep -Fq 'rollout status deployment/backend --timeout=3m' "$SCRIPT_DIR/reinitialize-k3s-network.sh"; then
+  fail "A scaled-to-zero backend must not use rollout status because stale ProgressDeadlineExceeded conditions fail immediately"
+fi
 deploy_lock_line="$(grep -nF -m1 'exec 8>/run/lock/talk-with-neighbors-deploy.lock' "$SCRIPT_DIR/deploy-via-ssm.sh" | cut -d: -f1)"
 release_dir_line="$(grep -nF -m1 'release_dir=/var/lib/talk-with-neighbors/release' "$SCRIPT_DIR/deploy-via-ssm.sh" | cut -d: -f1)"
 [[ "$deploy_lock_line" =~ ^[0-9]+$ && "$release_dir_line" =~ ^[0-9]+$ && "$deploy_lock_line" -lt "$release_dir_line" ]] || \

--- a/docs/deployment/aws-k3s.md
+++ b/docs/deployment/aws-k3s.md
@@ -324,6 +324,8 @@ REINITIALIZE_K3S_NETWORK:<EC2_INSTANCE_ID>:pods=10.244.0.0/16:services=10.96.0.0
 
 워크플로는 `main`, `production`, Environment 토글, boolean 입력, 인스턴스별 확인 문구가 모두 맞을 때만 진행한다. 실행 전 기존 k3s server 디렉터리와 설정 파일, MySQL 논리 dump를 EC2의 root 전용 백업 위치에 저장하고 무결성을 확인한다. PVC 복구 가능성을 훼손할 수 있으므로 `k3s-uninstall.sh`는 사용하지 않는다. 백업 뒤 k3s 네트워크를 목표 CIDR로 다시 만들고 노드·CoreDNS·Traefik을 확인한다. 이어서 MySQL을 다시 만들고 백업 dump를 한 번 복원한 뒤에만 백엔드를 시작한다. 커밋 전 실패에는 기존 server 상태와 설정으로 자동 롤백을 시도하며, root 전용 백업은 수동 복구를 위해 남긴다.
 
+재초기화가 MySQL dump나 k3s server archive를 만들기 전 `preparing-backup` 단계에서만 실패했다면, 다음 승인 실행은 root 소유 journal·백업 경로, 기존 replica 수, 파괴 단계 artifact 부재를 모두 다시 확인한다. 조건이 정확히 맞을 때만 이전 journal을 해당 백업의 `aborted-before-destructive.json`으로 보존하고 새 시도를 시작한다. 다른 phase이거나 dump·server archive가 하나라도 있으면 자동 재시도를 거부하므로 root 전용 journal과 백업을 먼저 조사해야 한다. 네트워크 마이그레이션 완료 뒤 애플리케이션 배포만 실패한 경우에는 `reinitialize_k3s_network=false`와 빈 확인 문구로만 재배포한다.
+
 성공 후에는 다음을 바로 수행한다.
 
 1. `K3S_NETWORK_REINITIALIZE_ALLOWED`를 `false`로 바꾸거나 삭제한다.


### PR DESCRIPTION
## Summary
- stop treating a scaled-to-zero backend as a rollout and wait directly for its pods to disappear
- preserve the backend's pre-migration availability so rollback only restores the state that actually existed
- allow an exact, root-only `preparing-backup` journal to be archived and retried only when replica/CIDR/inventory checks match and no dump, server archive, config backup, or checksum exists
- expose redacted migration journal metadata in the diagnostic artifact and document the retry contract

## Incident evidence
Deployment run 29315410909 failed before the MySQL dump or k3s server reset because the old backend Deployment already had `ProgressDeadlineExceeded`. Read-only diagnostics run 29315775915 confirmed:
- node remains on legacy Pod CIDR `10.42.0.0/24`
- MySQL and Redis are Ready, with direct database and Redis checks succeeding
- backend spec is restored to one replica and its pre-existing availability is zero
- the CIDR collision and Traefik failure remain unchanged

## Safety
- retries are rejected for every phase except `preparing-backup`
- previous journal, backup directory, inventory, owner/mode, canonical paths, release, Pod CIDR, and workload replicas must all match
- any destructive-phase artifact or existing archived journal blocks automatic retry
- the previous journal is retained as `aborted-before-destructive.json`

## Validation
- Bash syntax and diff checks passed
- workflow YAML parsed successfully
- two independent reviews found no remaining P0/P1 issue