### PR TITLE
Wait for k3s node registration during recovery

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -82,21 +82,64 @@ jobs:
               /var/lib/talk-with-neighbors/migrations/mysql-restore-v1.pending.json \
               /var/lib/talk-with-neighbors/migrations/mysql-restore-v1.done.json; do
               marker_name="$(basename "$marker")"
-              if [ -f "$marker" ] && [ ! -L "$marker" ]; then
+              if [ ! -e "$marker" ] && [ ! -L "$marker" ]; then
+                printf "%s absent\n" "$marker_name"
+              elif [ -L "$marker" ]; then
+                printf "%s unsafe-symlink\n" "$marker_name"
+              elif [ -f "$marker" ]; then
                 marker_phase="$(jq -r ".phase // \"n/a\"" "$marker" 2>/dev/null || echo invalid)"
                 marker_release="$(jq -r ".release_id // \"n/a\"" "$marker" 2>/dev/null || echo invalid)"
                 printf "%s owner=%s mode=%s phase=%s release=%s\n" \
                   "$marker_name" "$(stat -c "%u" "$marker")" "$(stat -c "%a" "$marker")" \
                   "$marker_phase" "$marker_release"
               else
-                printf "%s missing-or-unsafe\n" "$marker_name"
+                printf "%s unsafe-non-regular\n" "$marker_name"
               fi
             done
             echo "backup-directories:"
-            find /var/lib/talk-with-neighbors/backups -mindepth 1 -maxdepth 1 -type d \
-              -name "k3s-network-v1-*" -printf "%f\n" 2>/dev/null | sort || true
+            for backup in /var/lib/talk-with-neighbors/backups/k3s-network-v1-*; do
+              [ -e "$backup" ] || [ -L "$backup" ] || continue
+              backup_name="$(basename "$backup")"
+              if [ ! -d "$backup" ] || [ -L "$backup" ]; then
+                printf "%s unsafe\n" "$backup_name"
+                continue
+              fi
+              backup_owner="$(stat -c "%u" "$backup")"
+              backup_mode="$(stat -c "%a" "$backup")"
+              if [ -s "$backup/SHA256SUMS" ] && [ -s "$backup/mysql.sql.gz" ] \
+                && [ -s "$backup/server.tar.gz" ] && [ -s "$backup/k3s-config.yaml" ]; then
+                checksum_status=fail
+                mysql_gzip_status=fail
+                server_tar_status=fail
+                (cd "$backup" && sha256sum --check --status SHA256SUMS) && checksum_status=ok
+                gzip -t "$backup/mysql.sql.gz" && mysql_gzip_status=ok
+                tar -tzf "$backup/server.tar.gz" >/dev/null && server_tar_status=ok
+                printf "%s owner=%s mode=%s full-backup checksum=%s mysql-gzip=%s server-tar=%s\n" \
+                  "$backup_name" "$backup_owner" "$backup_mode" "$checksum_status" \
+                  "$mysql_gzip_status" "$server_tar_status"
+              else
+                printf "%s owner=%s mode=%s partial-backup\n" \
+                  "$backup_name" "$backup_owner" "$backup_mode"
+              fi
+            done
+            if flock -n /run/lock/talk-with-neighbors-deploy.lock -c true; then
+              echo "deploy-lock=free"
+            else
+              echo "deploy-lock=busy"
+            fi
             k3s kubectl get nodes -o wide
             k3s kubectl -n "$namespace" get pods,deployments,statefulsets,services,ingress -o wide
+            pvc_json="$(k3s kubectl -n "$namespace" get persistentvolumeclaims -o json)"
+            echo "pvc-total=$(printf "%s" "$pvc_json" | jq ".items | length")"
+            echo "pvc-bound=$(printf "%s" "$pvc_json" | jq "[.items[] | select(.status.phase == \"Bound\")] | length")"
+            storage_path=/var/lib/rancher/k3s/storage
+            if [ -d "$storage_path" ] && [ ! -L "$storage_path" ] \
+              && [ "$(readlink -e "$storage_path")" = "$storage_path" ]; then
+              echo "storage-path=safe"
+              echo "storage-directory-count=$(find "$storage_path" -mindepth 1 -maxdepth 1 -type d | wc -l)"
+            else
+              echo "storage-path=unsafe"
+            fi
             k3s kubectl -n kube-system get pods,services -o wide
             k3s kubectl -n kube-system get jobs,helmcharts.helm.cattle.io -o wide
             echo "=== cluster CIDR and resolver routes ==="
@@ -143,6 +186,16 @@ jobs:
               MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -u twn talk_with_neighbors -e "SELECT 1" >/dev/null
             '\''; then
               echo "database-query=up"
+              database_counts="$(k3s kubectl -n "$namespace" exec statefulset/mysql -- sh -ec '\''
+                MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -u twn talk_with_neighbors -e "
+                  SELECT CONCAT(\"application-table-count=\", COUNT(*))
+                    FROM information_schema.tables WHERE table_schema = DATABASE();
+                  SELECT CONCAT(\"users-row-count=\", COUNT(*)) FROM users;
+                  SELECT CONCAT(\"feed-posts-row-count=\", COUNT(*)) FROM feed_posts;
+                  SELECT CONCAT(\"messages-row-count=\", COUNT(*)) FROM messages;
+                "
+              '\'' 2>/dev/null || echo "database-counts=unavailable")"
+              printf "%s\n" "$database_counts"
             else
               echo "database-query=down"
             fi

--- a/deploy/k8s/k3s-network-common.sh
+++ b/deploy/k8s/k3s-network-common.sh
@@ -35,3 +35,19 @@ k3s_config_has_desired_network() {
     grep -Fqx 'service-cidr: "10.96.0.0/16"' "$config_file" &&
     grep -Fqx 'cluster-dns: "10.96.0.10"' "$config_file"
 }
+
+k3s_wait_for_single_node_registration() {
+  local attempts="${1:-120}"
+  local attempt node_name
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if node_name="$(
+      k3s kubectl get nodes -o json 2>/dev/null \
+        | jq -er 'if (.items | length) == 1 then .items[0].metadata.name else empty end'
+    )" && [[ -n "$node_name" ]]; then
+      printf '%s\n' "$node_name"
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}

--- a/deploy/k8s/reinitialize-k3s-network.sh
+++ b/deploy/k8s/reinitialize-k3s-network.sh
@@ -472,7 +472,8 @@ cluster_stopped=false
 
 write_phase "verifying-new-cluster"
 wait_for_k3s_api 180 || die "The reinitialized k3s API did not become ready"
-k3s kubectl wait --for=condition=Ready node --all --timeout=5m
+new_node_name="$(k3s_wait_for_single_node_registration 120)" || die "The reinitialized k3s node did not register"
+k3s kubectl wait --for=condition=Ready "node/$new_node_name" --timeout=5m
 node_count="$(k3s kubectl get nodes -o json | jq -er '.items | length')"
 [[ "$node_count" == "1" ]] || die "The reinitialized cluster does not contain exactly one node"
 new_pod_cidr="$(k3s kubectl get nodes -o json | jq -er '.items[0].spec.podCIDR')"

--- a/deploy/k8s/tests/test-k3s-network-reinitialize.sh
+++ b/deploy/k8s/tests/test-k3s-network-reinitialize.sh
@@ -47,6 +47,73 @@ grep -Fq 'The previous migration advanced beyond the safe pre-destructive retry 
 if grep -Fq 'rollout status deployment/backend --timeout=3m' "$SCRIPT_DIR/reinitialize-k3s-network.sh"; then
   fail "A scaled-to-zero backend must not use rollout status because stale ProgressDeadlineExceeded conditions fail immediately"
 fi
+grep -Fq 'k3s_wait_for_single_node_registration' "$SCRIPT_DIR/reinitialize-k3s-network.sh" || \
+  fail "The reset must wait for a node object after the k3s API becomes ready"
+grep -Fq 'if (.items | length) == 1 then .items[0].metadata.name else empty end' "$SCRIPT_DIR/k3s-network-common.sh" || \
+  fail "The node-registration wait must require exactly one node"
+if grep -Fq 'kubectl wait --for=condition=Ready node --all' "$SCRIPT_DIR/reinitialize-k3s-network.sh"; then
+  fail "kubectl wait --all fails when the API is ready before the first node object registers"
+fi
+node_registration_line="$(grep -nF -m1 'new_node_name="$(k3s_wait_for_single_node_registration 120)"' "$SCRIPT_DIR/reinitialize-k3s-network.sh" | cut -d: -f1)"
+node_ready_line="$(grep -nF -m1 'kubectl wait --for=condition=Ready "node/$new_node_name"' "$SCRIPT_DIR/reinitialize-k3s-network.sh" | cut -d: -f1)"
+[[ "$node_registration_line" =~ ^[0-9]+$ && "$node_ready_line" =~ ^[0-9]+$ && "$node_registration_line" -lt "$node_ready_line" ]] || \
+  fail "The reset must observe node registration before waiting for node readiness"
+
+temporary="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$temporary"
+}
+trap cleanup EXIT
+
+node_probe_count_file="$temporary/node-probe-count"
+k3s() {
+  [[ "$*" == "kubectl get nodes -o json" ]] || return 2
+  local probe_count
+  probe_count="$(< "$node_probe_count_file")"
+  probe_count=$((probe_count + 1))
+  printf '%s\n' "$probe_count" > "$node_probe_count_file"
+  case "$K3S_NODE_TEST_SCENARIO" in
+    delayed)
+      if (( probe_count < 3 )); then
+        printf '{"items":[]}\n'
+      else
+        printf '{"items":[{"metadata":{"name":"node-a"}}]}\n'
+      fi
+      ;;
+    empty)
+      printf '{"items":[]}\n'
+      ;;
+    multiple)
+      printf '{"items":[{"metadata":{"name":"node-a"}},{"metadata":{"name":"node-b"}}]}\n'
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+sleep() {
+  :
+}
+
+printf '0\n' > "$node_probe_count_file"
+K3S_NODE_TEST_SCENARIO=delayed
+[[ "$(k3s_wait_for_single_node_registration 3)" == "node-a" ]] || \
+  fail "The node-registration wait did not tolerate an API-ready registration delay"
+
+printf '0\n' > "$node_probe_count_file"
+K3S_NODE_TEST_SCENARIO=empty
+if k3s_wait_for_single_node_registration 2 >/dev/null; then
+  fail "The node-registration wait accepted an empty node list"
+fi
+
+printf '0\n' > "$node_probe_count_file"
+K3S_NODE_TEST_SCENARIO=multiple
+if k3s_wait_for_single_node_registration 2 >/dev/null; then
+  fail "The single-node migration accepted multiple registered nodes"
+fi
+unset -f k3s sleep
+unset K3S_NODE_TEST_SCENARIO node_probe_count_file
+
 deploy_lock_line="$(grep -nF -m1 'exec 8>/run/lock/talk-with-neighbors-deploy.lock' "$SCRIPT_DIR/deploy-via-ssm.sh" | cut -d: -f1)"
 release_dir_line="$(grep -nF -m1 'release_dir=/var/lib/talk-with-neighbors/release' "$SCRIPT_DIR/deploy-via-ssm.sh" | cut -d: -f1)"
 [[ "$deploy_lock_line" =~ ^[0-9]+$ && "$release_dir_line" =~ ^[0-9]+$ && "$deploy_lock_line" -lt "$release_dir_line" ]] || \
@@ -58,12 +125,6 @@ restore_call_line="$(grep -n '^  restore_pending_mysql_dump$' "$SCRIPT_DIR/deplo
 full_apply_line="$(grep -n 'apply -k "$RELEASE_DIR/base"' "$SCRIPT_DIR/deploy-on-node.sh" | cut -d: -f1)"
 [[ "$restore_call_line" =~ ^[0-9]+$ && "$full_apply_line" =~ ^[0-9]+$ && "$restore_call_line" -lt "$full_apply_line" ]] || \
   fail "MySQL restore must complete before the full application kustomization"
-
-temporary="$(mktemp -d)"
-cleanup() {
-  rm -rf -- "$temporary"
-}
-trap cleanup EXIT
 
 PUBLIC_ORIGIN=http://127.0.0.1 \
 AWS_REGION=ap-northeast-2 \

--- a/deploy/k8s/tests/test-k3s-network-reinitialize.sh
+++ b/deploy/k8s/tests/test-k3s-network-reinitialize.sh
@@ -54,7 +54,10 @@ grep -Fq 'if (.items | length) == 1 then .items[0].metadata.name else empty end'
 if grep -Fq 'kubectl wait --for=condition=Ready node --all' "$SCRIPT_DIR/reinitialize-k3s-network.sh"; then
   fail "kubectl wait --all fails when the API is ready before the first node object registers"
 fi
+# These are intentional literal source-code patterns.
+# shellcheck disable=SC2016
 node_registration_line="$(grep -nF -m1 'new_node_name="$(k3s_wait_for_single_node_registration 120)"' "$SCRIPT_DIR/reinitialize-k3s-network.sh" | cut -d: -f1)"
+# shellcheck disable=SC2016
 node_ready_line="$(grep -nF -m1 'kubectl wait --for=condition=Ready "node/$new_node_name"' "$SCRIPT_DIR/reinitialize-k3s-network.sh" | cut -d: -f1)"
 [[ "$node_registration_line" =~ ^[0-9]+$ && "$node_ready_line" =~ ^[0-9]+$ && "$node_registration_line" -lt "$node_ready_line" ]] || \
   fail "The reset must observe node registration before waiting for node readiness"
@@ -66,6 +69,8 @@ cleanup() {
 trap cleanup EXIT
 
 node_probe_count_file="$temporary/node-probe-count"
+# Invoked indirectly by k3s_wait_for_single_node_registration.
+# shellcheck disable=SC2329
 k3s() {
   [[ "$*" == "kubectl get nodes -o json" ]] || return 2
   local probe_count
@@ -91,6 +96,8 @@ k3s() {
       ;;
   esac
 }
+# Invoked indirectly by k3s_wait_for_single_node_registration.
+# shellcheck disable=SC2329
 sleep() {
   :
 }


### PR DESCRIPTION
## Summary
- wait for exactly one k3s Node object to register after the API becomes ready
- target the discovered Node by name for the Ready wait instead of using `node --all`
- add delayed, empty, and multi-node regression cases
- strengthen redacted diagnostics with explicit marker safety, backup integrity, PVC/storage, deployment-lock, and database-count checks

## Incident evidence
Recovery run `29317077993` reached the new API, then `kubectl wait --for=condition=Ready node --all` returned `error: no matching resources found` before the first Node object registered. Automatic rollback restored the old server state; post-rollback diagnostics show the legacy Pod CIDR, no migration markers, and healthy MySQL/Redis checks.

## Local verification
- Bash syntax checks passed
- workflow YAML parsed and all extracted runner scripts passed `bash -n`
- `git diff --check` passed
- guarded migration test passed with the real jq CLI
- two independent reviews found no P0/P1 issues

AWS recovery will only be retried after all PR checks pass and this exact head is merged.