### PR TITLE
Fix transactional chat room deletion and add MySQL regression CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
           cache: gradle
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - run: chmod +x gradlew
-      - run: ./gradlew clean test bootJar --no-daemon
+      - name: Run unit tests, MySQL integration tests, and package
+        env:
+          MYSQL_IT_URL: jdbc:mysql://127.0.0.1:3306/talk_with_neighbors?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+          MYSQL_IT_USERNAME: twn
+          MYSQL_IT_PASSWORD: ci-password
+        run: ./gradlew clean test mysqlIntegrationTest bootJar --no-daemon
       - name: Validate production compose
         env:
           MYSQL_PASSWORD: ci-password
@@ -105,6 +110,6 @@ jobs:
         if: always()
         with:
           name: backend-test-report
-          path: build/reports/tests/test
+          path: build/reports/tests/**
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -52,7 +52,12 @@ jobs:
           cache: gradle
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - run: chmod +x gradlew
-      - run: ./gradlew clean test bootJar --no-daemon
+      - name: Run unit tests, MySQL integration tests, and package
+        env:
+          MYSQL_IT_URL: jdbc:mysql://127.0.0.1:3306/talk_with_neighbors?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+          MYSQL_IT_USERNAME: twn
+          MYSQL_IT_PASSWORD: publish-ci-password
+        run: ./gradlew clean test mysqlIntegrationTest bootJar --no-daemon
       - name: Validate production compose
         env:
           MYSQL_PASSWORD: publish-ci-password

--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,24 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	useJUnitPlatform {
+		excludeTags 'mysql'
+	}
 	systemProperty 'spring.profiles.active', 'test'
+	jvmArgs '-Dfile.encoding=UTF-8'
+}
+
+tasks.register('mysqlIntegrationTest', Test) {
+	group = 'verification'
+	description = 'Runs commit-level persistence tests against MySQL.'
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	useJUnitPlatform {
+		includeTags 'mysql'
+	}
+	systemProperty 'spring.profiles.active', 'mysql-it'
+	maxParallelForks = 1
+	shouldRunAfter tasks.test
 	jvmArgs '-Dfile.encoding=UTF-8'
 }
 

--- a/src/main/java/com/talkwithneighbors/domain/event/ChatRoomDeletedEvent.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/ChatRoomDeletedEvent.java
@@ -1,0 +1,46 @@
+package com.talkwithneighbors.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Durable domain event emitted in the same transaction as a chat-room deletion. */
+public record ChatRoomDeletedEvent(
+        String eventId,
+        LocalDateTime occurredAt,
+        String roomId,
+        List<Long> participantIds
+) implements DomainEvent {
+    public static final String TYPE = "CHAT_ROOM_DELETED";
+
+    public ChatRoomDeletedEvent {
+        participantIds = participantIds == null
+                ? List.of()
+                : participantIds.stream().filter(Objects::nonNull).distinct().toList();
+    }
+
+    public static ChatRoomDeletedEvent create(String roomId, List<Long> participantIds) {
+        return new ChatRoomDeletedEvent(
+                UUID.randomUUID().toString(),
+                LocalDateTime.now(),
+                roomId,
+                participantIds
+        );
+    }
+
+    @Override
+    public String eventType() {
+        return TYPE;
+    }
+
+    @Override
+    public String aggregateType() {
+        return "ChatRoom";
+    }
+
+    @Override
+    public String aggregateId() {
+        return roomId;
+    }
+}

--- a/src/main/java/com/talkwithneighbors/domain/event/DomainNotificationEventListener.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/DomainNotificationEventListener.java
@@ -82,6 +82,44 @@ public class DomainNotificationEventListener {
         );
     }
 
+    @EventListener
+    public void onChatRoomDeleted(ChatRoomDeletedEvent event) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("eventId", event.eventId());
+        data.put("chatRoomId", event.roomId());
+
+        WebSocketNotification<Map<String, Object>> notification = new WebSocketNotification<>(
+                "ROOM_DELETED",
+                data,
+                "채팅방이 삭제되었어.",
+                "/chat"
+        );
+
+        event.participantIds().forEach(participantId -> {
+            redisSessionService.clearUserCurrentRoomIfMatches(
+                    participantId.toString(), event.roomId());
+            deliver(
+                    participantId,
+                    "/queue/chat-notifications",
+                    notification,
+                    OfflineNotification.NotificationType.ROOM_DELETED,
+                    8
+            );
+
+            // The notification queue shows the toast; the updates queue removes
+            // the room from an already-open chat list.
+            try {
+                if (redisSessionService.isUserOnline(participantId.toString())) {
+                    messagingTemplate.convertAndSendToUser(
+                            participantId.toString(), "/queue/chat-updates", notification);
+                }
+            } catch (Exception exception) {
+                log.warn("Failed to dispatch chat-room removal update. roomId={}, userId={}",
+                        event.roomId(), participantId, exception);
+            }
+        });
+    }
+
     private void deliver(
             Long userId,
             String destination,
@@ -103,7 +141,18 @@ public class DomainNotificationEventListener {
                     priority
             );
             if (redisSessionService.isUserOnline(userId.toString())) {
-                messagingTemplate.convertAndSendToUser(userId.toString(), destination, notification);
+                try {
+                    messagingTemplate.convertAndSendToUser(
+                            userId.toString(), destination, notification);
+                } catch (Exception exception) {
+                    // The durable notification stays pending and can be delivered when
+                    // the user reconnects; a transient socket failure must not retry
+                    // the whole outbox event and duplicate earlier recipients.
+                    log.warn("WebSocket delivery failed; offline notification remains pending. "
+                                    + "userId={}, destination={}",
+                            userId, destination, exception);
+                    return;
+                }
                 if (saved != null) {
                     offlineNotificationService.markAsDelivered(saved.getId());
                 }

--- a/src/main/java/com/talkwithneighbors/outbox/DomainEventSerializer.java
+++ b/src/main/java/com/talkwithneighbors/outbox/DomainEventSerializer.java
@@ -7,6 +7,7 @@ import com.talkwithneighbors.domain.event.MatchCompletedEvent;
 import com.talkwithneighbors.domain.event.MeetupJoinedEvent;
 import com.talkwithneighbors.domain.event.UserBlockedEvent;
 import com.talkwithneighbors.domain.event.ContentReportedEvent;
+import com.talkwithneighbors.domain.event.ChatRoomDeletedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,7 @@ public class DomainEventSerializer {
             case MeetupJoinedEvent.TYPE -> objectMapper.readValue(payload, MeetupJoinedEvent.class);
             case UserBlockedEvent.TYPE -> objectMapper.readValue(payload, UserBlockedEvent.class);
             case ContentReportedEvent.TYPE -> objectMapper.readValue(payload, ContentReportedEvent.class);
+            case ChatRoomDeletedEvent.TYPE -> objectMapper.readValue(payload, ChatRoomDeletedEvent.class);
             default -> throw new IllegalArgumentException("Unsupported domain event type: " + eventType);
         };
     }

--- a/src/main/java/com/talkwithneighbors/outbox/OutboxRelay.java
+++ b/src/main/java/com/talkwithneighbors/outbox/OutboxRelay.java
@@ -17,7 +17,14 @@ public class OutboxRelay {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deliverAfterCommit(OutboxEventStored event) {
-        outboxEventProcessor.process(event.eventId());
+        try {
+            outboxEventProcessor.process(event.eventId());
+        } catch (Exception exception) {
+            // The originating database transaction has already committed. Never turn
+            // a successful HTTP mutation into a false 500; the scheduler will retry.
+            log.warn("Immediate outbox delivery failed; scheduled retry will continue. eventId={}",
+                    event.eventId(), exception);
+        }
     }
 
     @Scheduled(fixedDelayString = "${app.outbox.retry-interval-ms:5000}")

--- a/src/main/java/com/talkwithneighbors/repository/ChatRoomDeletionRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/ChatRoomDeletionRepository.java
@@ -1,0 +1,111 @@
+package com.talkwithneighbors.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Deletes the complete database graph owned by a chat room in foreign-key order.
+ *
+ * <p>The regular JPA entity delete is deliberately not used here. Chat messages own
+ * two element-collection tables, while meetup rooms can also own wait-list rows.
+ * Mixing managed entities with native and JPQL bulk deletes leaves the persistence
+ * context stale and can defer a constraint failure until transaction commit.</p>
+ */
+@Repository
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class ChatRoomDeletionRepository {
+    private final EntityManager entityManager;
+
+    public List<String> findMediaUrlsByRoomId(String roomId) {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = entityManager.createNativeQuery("""
+                        SELECT a.media_url, a.thumbnail_url
+                        FROM message_attachments a
+                        INNER JOIN messages m ON m.id = a.message_id
+                        WHERE m.chat_room_id = :roomId
+                        ORDER BY a.message_id, a.sort_order
+                        """)
+                .setParameter("roomId", roomId)
+                .getResultList();
+
+        LinkedHashSet<String> urls = new LinkedHashSet<>();
+        for (Object[] row : rows) {
+            addUrl(urls, row[0]);
+            addUrl(urls, row[1]);
+        }
+        return List.copyOf(urls);
+    }
+
+    public ChatRoomDeletionResult deleteByRoomId(String roomId) {
+        // Make every pending entity change visible before executing bulk DML.
+        entityManager.flush();
+
+        int waitlistEntries = executeDelete(
+                "DELETE FROM meetup_waitlist WHERE room_id = :roomId", roomId);
+        int readStatuses = executeDelete("""
+                DELETE FROM message_read_by
+                WHERE message_id IN (
+                    SELECT id FROM messages WHERE chat_room_id = :roomId
+                )
+                """, roomId);
+        int attachments = executeDelete("""
+                DELETE FROM message_attachments
+                WHERE message_id IN (
+                    SELECT id FROM messages WHERE chat_room_id = :roomId
+                )
+                """, roomId);
+        int messages = executeDelete(
+                "DELETE FROM messages WHERE chat_room_id = :roomId", roomId);
+        int interestTags = executeDelete(
+                "DELETE FROM chat_room_interest_tags WHERE chat_room_id = :roomId", roomId);
+        int participants = executeDelete(
+                "DELETE FROM chat_room_participants WHERE chat_room_id = :roomId", roomId);
+        int rooms = executeDelete(
+                "DELETE FROM chat_rooms WHERE id = :roomId", roomId);
+
+        // Native DML bypasses the first-level cache; detach stale room/message entities.
+        entityManager.clear();
+        return new ChatRoomDeletionResult(
+                waitlistEntries,
+                readStatuses,
+                attachments,
+                messages,
+                interestTags,
+                participants,
+                rooms
+        );
+    }
+
+    private int executeDelete(String sql, String roomId) {
+        return entityManager.createNativeQuery(sql)
+                .setParameter("roomId", roomId)
+                .executeUpdate();
+    }
+
+    private void addUrl(LinkedHashSet<String> urls, Object candidate) {
+        if (candidate != null) {
+            String url = candidate.toString();
+            if (!url.isBlank()) {
+                urls.add(url);
+            }
+        }
+    }
+
+    public record ChatRoomDeletionResult(
+            int waitlistEntries,
+            int readStatuses,
+            int attachments,
+            int messages,
+            int interestTags,
+            int participants,
+            int rooms
+    ) {
+    }
+}

--- a/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
@@ -4,7 +4,6 @@ import com.talkwithneighbors.entity.Message;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -32,30 +31,6 @@ public interface MessageRepository extends JpaRepository<Message, String> {
 
     @Query("SELECT DISTINCT m FROM Message m LEFT JOIN FETCH m.attachments WHERE m.chatRoom.id = :roomId")
     List<Message> findAllWithAttachmentsByChatRoomId(@Param("roomId") String roomId);
-
-    /**
-     * 특정 채팅방의 모든 메시지 읽음 상태를 삭제합니다.
-     * 메시지 삭제 전에 먼저 실행되어야 합니다.
-     * 
-     * @param chatRoomId 채팅방 ID
-     */
-    @Modifying
-    @Query(value = "DELETE FROM message_read_by WHERE message_id IN (SELECT id FROM messages WHERE chat_room_id = :chatRoomId)", nativeQuery = true)
-    void deleteReadStatusByChatRoomId(@Param("chatRoomId") String chatRoomId);
-
-    @Modifying
-    @Query(value = "DELETE FROM message_attachments WHERE message_id IN (SELECT id FROM messages WHERE chat_room_id = :chatRoomId)", nativeQuery = true)
-    void deleteAttachmentsByChatRoomId(@Param("chatRoomId") String chatRoomId);
-
-    /**
-     * 특정 채팅방의 모든 메시지를 삭제합니다.
-     * 읽음 상태가 먼저 삭제된 후 실행되어야 합니다.
-     * 
-     * @param chatRoomId 채팅방 ID
-     */
-    @Modifying
-    @Query("DELETE FROM Message m WHERE m.chatRoom.id = :chatRoomId")
-    void deleteByChatRoomId(@Param("chatRoomId") String chatRoomId);
 
     @Query("SELECT m FROM Message m WHERE m.chatRoom.id = :roomId AND :userId NOT IN (SELECT u FROM m.readByUsers u)")
     List<Message> findUnreadMessages(@Param("roomId") String roomId, @Param("userId") Long userId);

--- a/src/main/java/com/talkwithneighbors/service/RedisSessionService.java
+++ b/src/main/java/com/talkwithneighbors/service/RedisSessionService.java
@@ -9,6 +9,7 @@ import com.talkwithneighbors.security.UserSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,6 +58,13 @@ public class RedisSessionService implements ApplicationListener<SessionDisconnec
     private static final long ONLINE_EXPIRATION = 5 * 60; // 5분
     private static final long CURRENT_ROOM_EXPIRATION = 30 * 60; // 30분 (채팅방 입장 상태 만료)
     private static final long SESSION_TIMEOUT_MINUTES = 30;
+    private static final DefaultRedisScript<Long> CLEAR_CURRENT_ROOM_IF_MATCHES =
+            new DefaultRedisScript<>("""
+                    if redis.call('get', KEYS[1]) == ARGV[1] then
+                        return redis.call('del', KEYS[1])
+                    end
+                    return 0
+                    """, Long.class);
 
     @Transactional
     public void saveSession(String sessionId, UserSession userSession) {
@@ -591,6 +599,25 @@ public class RedisSessionService implements ApplicationListener<SessionDisconnec
             log.info("[RedisSessionService] User {} left current room", userId);
         } catch (Exception e) {
             log.error("[RedisSessionService] Error clearing user current room for userId: {}", userId, e);
+        }
+    }
+
+    /**
+     * Clears presence for a deleted room without racing a user who has already
+     * moved to another room.
+     */
+    public void clearUserCurrentRoomIfMatches(String userId, String expectedRoomId) {
+        try {
+            String key = USER_CURRENT_ROOM_PREFIX + userId;
+            redisTemplate.execute(
+                    CLEAR_CURRENT_ROOM_IF_MATCHES,
+                    List.of(key),
+                    expectedRoomId
+            );
+        } catch (Exception exception) {
+            // Presence is ephemeral. A Redis failure must not fail durable outbox delivery.
+            log.warn("[RedisSessionService] Failed to clear deleted current room. userId={}, roomId={}",
+                    userId, expectedRoomId, exception);
         }
     }
     

--- a/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
@@ -6,6 +6,7 @@ import com.talkwithneighbors.dto.MessageDto;
 import com.talkwithneighbors.dto.UpdateChatRoomRequest;
 import com.talkwithneighbors.domain.event.ChatMessageCommittedEvent;
 import com.talkwithneighbors.domain.event.ChatMessageChangedEvent;
+import com.talkwithneighbors.domain.event.ChatRoomDeletedEvent;
 import com.talkwithneighbors.domain.event.MediaFilesDeletedEvent;
 import com.talkwithneighbors.entity.ChatRoom;
 import com.talkwithneighbors.entity.ChatRoomType;
@@ -16,11 +17,13 @@ import com.talkwithneighbors.entity.Message.MessageType;
 import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.exception.ChatException;
 import com.talkwithneighbors.repository.ChatRoomRepository;
+import com.talkwithneighbors.repository.ChatRoomDeletionRepository;
 import com.talkwithneighbors.repository.MessageRepository;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.repository.UserBlockRepository;
 import com.talkwithneighbors.service.ChatService;
 import com.talkwithneighbors.service.NotificationService;
+import com.talkwithneighbors.outbox.DomainEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -29,16 +32,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,10 +52,11 @@ public class ChatServiceImpl implements ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
-    private final SimpMessagingTemplate messagingTemplate;
     private final NotificationService notificationService;
     private final UserBlockRepository userBlockRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ChatRoomDeletionRepository chatRoomDeletionRepository;
+    private final DomainEventPublisher domainEventPublisher;
 
     @Override
     @Transactional
@@ -153,9 +154,10 @@ public class ChatServiceImpl implements ChatService {
     public ChatRoomDto getRoomById(String roomId, String userIdString) {
         Long userId = Long.parseLong(userIdString);
         User currentUser = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new ChatException("User not found with id: " + userId, HttpStatus.NOT_FOUND));
         ChatRoom chatRoom = chatRoomRepository.findByIdAndParticipantsContaining(roomId, currentUser)
-                .orElseThrow(() -> new RuntimeException("Chat room not found or user not a participant"));
+                .orElseThrow(() -> new ChatException(
+                        "Chat room not found or user not a participant", HttpStatus.NOT_FOUND));
         return ChatRoomDto.fromEntity(chatRoom, currentUser, messageRepository);
     }
 
@@ -550,97 +552,50 @@ public class ChatServiceImpl implements ChatService {
     @Transactional
     public void deleteRoom(String roomId) {
         log.info("[deleteRoom] Starting deletion process for roomId: {}", roomId);
-        
+
         try {
-            ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                    .orElseThrow(() -> new ChatException("Chat room not found: " + roomId, HttpStatus.NOT_FOUND));
-            
-            log.info("[deleteRoom] Found chat room: {} with {} participants", roomId, chatRoom.getParticipants().size());
-            
-            // 참여자들에게 알림 보내기 (삭제 전에)
+            ChatRoom chatRoom = chatRoomRepository.findByIdForUpdate(roomId)
+                    .orElseThrow(() -> new ChatException(
+                            "Chat room not found: " + roomId, HttpStatus.NOT_FOUND));
+
             List<Long> participantIds = chatRoom.getParticipants().stream()
                     .map(User::getId)
-                    .collect(Collectors.toList());
-            List<String> attachmentUrls = messageRepository.findAllWithAttachmentsByChatRoomId(roomId).stream()
-                    .flatMap(message -> message.getAttachments().stream())
-                    .flatMap(attachment -> java.util.stream.Stream.of(
-                            attachment.getUrl(), attachment.getThumbnailUrl()))
                     .filter(java.util.Objects::nonNull)
-                    .filter(url -> !url.isBlank())
                     .distinct()
                     .toList();
-            
-            log.info("[deleteRoom] Notifying {} participants before deletion", participantIds.size());
-            
-            // 1. 먼저 메시지 읽음 상태 삭제
-            try {
-                messageRepository.deleteReadStatusByChatRoomId(roomId);
-                log.info("[deleteRoom] Successfully deleted message read statuses for roomId: {}", roomId);
-            } catch (Exception e) {
-                log.warn("[deleteRoom] Failed to delete message read statuses for roomId: {} - {}", roomId, e.getMessage());
-                // 읽음 상태 삭제 실패 시에도 계속 진행 (메시지 삭제 시 함께 삭제될 수 있음)
-            }
-            
-            // 2. 그 다음 메시지 삭제
-            try {
-                messageRepository.deleteAttachmentsByChatRoomId(roomId);
-                log.info("[deleteRoom] Successfully deleted message attachments for roomId: {}", roomId);
-            } catch (Exception e) {
-                log.error("[deleteRoom] Failed to delete message attachments for roomId: {} - {}", roomId, e.getMessage());
-                throw new ChatException("메시지 첨부 정보 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+            List<String> attachmentUrls =
+                    chatRoomDeletionRepository.findMediaUrlsByRoomId(roomId);
+
+            ChatRoomDeletionRepository.ChatRoomDeletionResult result =
+                    chatRoomDeletionRepository.deleteByRoomId(roomId);
+            if (result.rooms() != 1) {
+                throw new IllegalStateException(
+                        "Expected to delete one chat room but deleted " + result.rooms());
             }
 
-            try {
-                messageRepository.deleteByChatRoomId(roomId);
-                log.info("[deleteRoom] Successfully deleted messages for roomId: {}", roomId);
-            } catch (Exception e) {
-                log.error("[deleteRoom] Failed to delete messages for roomId: {} - {}", roomId, e.getMessage());
-                throw new ChatException("메시지 삭제 중 오류가 발생했습니다: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-            
-            // 3. 마지막으로 채팅방 삭제
-            chatRoomRepository.delete(chatRoom);
-            log.info("[deleteRoom] Successfully deleted chat room: {}", roomId);
             if (!attachmentUrls.isEmpty()) {
-                applicationEventPublisher.publishEvent(new MediaFilesDeletedEvent(attachmentUrls));
+                applicationEventPublisher.publishEvent(
+                        new MediaFilesDeletedEvent(attachmentUrls));
             }
-            
-            // 참여자들에게 WebSocket 알림 전송
-            for (Long participantId : participantIds) {
-                try {
-                    Map<String, Object> deleteNotification = Map.of(
-                        "type", "ROOM_DELETED",
-                        "roomId", roomId,
-                        "message", "채팅방이 삭제되었습니다."
-                    );
-                    
-                    String destination = "/queue/chat-notifications";
-                    messagingTemplate.convertAndSendToUser(
-                        participantId.toString(), 
-                        destination, 
-                        deleteNotification
-                    );
-                    log.info("[deleteRoom] Sent room deletion notification to user: {}", participantId);
-                    
-                    // 대안적 메시지 전송도 시도
-                    String alternativeDestination = "/topic/chat-event-" + participantId;
-                    messagingTemplate.convertAndSend(alternativeDestination, deleteNotification);
-                    log.info("[deleteRoom] Sent alternative room deletion notification to: {}", alternativeDestination);
-                    
-                } catch (Exception e) {
-                    log.warn("[deleteRoom] Failed to send deletion notification to user {}: {}", participantId, e.getMessage());
-                    // 알림 전송 실패는 전체 삭제 과정을 실패시키지 않음
-                }
-            }
-            
-            log.info("[deleteRoom] Successfully completed deletion process for roomId: {} (including read statuses)", roomId);
-            
-        } catch (ChatException e) {
-            log.error("[deleteRoom] ChatException during deletion of roomId {}: {}", roomId, e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            log.error("[deleteRoom] Unexpected error during deletion of roomId {}: {}", roomId, e.getMessage(), e);
-            throw new ChatException("채팅방 삭제 중 오류가 발생했습니다: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            domainEventPublisher.publish(
+                    ChatRoomDeletedEvent.create(roomId, participantIds));
+
+            log.info(
+                    "[deleteRoom] Deleted room graph. roomId={}, messages={}, attachments={}, "
+                            + "readStatuses={}, participants={}, waitlistEntries={}",
+                    roomId,
+                    result.messages(),
+                    result.attachments(),
+                    result.readStatuses(),
+                    result.participants(),
+                    result.waitlistEntries()
+            );
+        } catch (ChatException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            log.error("[deleteRoom] Failed to delete roomId={}", roomId, exception);
+            throw new ChatException(
+                    "Failed to delete chat room.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/com/talkwithneighbors/controller/ChatControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/ChatControllerTest.java
@@ -42,6 +42,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -288,6 +290,19 @@ class ChatControllerTest {
         mockMvc.perform(delete("/api/chat/rooms/{roomId}", "room-1")
                         .header(SESSION_HEADER, SESSION_ID))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteMissingRoomReturnsNotFound() throws Exception {
+        when(chatService.getRoomById(eq("missing-room"), anyString()))
+                .thenThrow(new ChatException("Chat room not found", HttpStatus.NOT_FOUND));
+
+        mockMvc.perform(delete("/api/chat/rooms/{roomId}", "missing-room")
+                        .header(SESSION_HEADER, SESSION_ID))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verify(chatService, never()).deleteRoom(anyString());
     }
 
     @Test

--- a/src/test/java/com/talkwithneighbors/domain/event/DomainNotificationEventListenerTest.java
+++ b/src/test/java/com/talkwithneighbors/domain/event/DomainNotificationEventListenerTest.java
@@ -1,0 +1,99 @@
+package com.talkwithneighbors.domain.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.talkwithneighbors.dto.notification.WebSocketNotification;
+import com.talkwithneighbors.entity.OfflineNotification;
+import com.talkwithneighbors.service.OfflineNotificationService;
+import com.talkwithneighbors.service.RedisSessionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DomainNotificationEventListenerTest {
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RedisSessionService redisSessionService;
+
+    @Mock
+    private OfflineNotificationService offlineNotificationService;
+
+    @Test
+    void roomDeletionClearsPresenceAndUpdatesBothChatQueues() {
+        DomainNotificationEventListener listener = new DomainNotificationEventListener(
+                messagingTemplate,
+                redisSessionService,
+                offlineNotificationService,
+                new ObjectMapper()
+        );
+        when(redisSessionService.isUserOnline("1")).thenReturn(true);
+        ChatRoomDeletedEvent event = ChatRoomDeletedEvent.create("room-1", List.of(1L));
+
+        listener.onChatRoomDeleted(event);
+
+        verify(redisSessionService).clearUserCurrentRoomIfMatches("1", "room-1");
+        verify(offlineNotificationService).saveOfflineNotification(
+                eq(1L),
+                eq(OfflineNotification.NotificationType.ROOM_DELETED),
+                any(String.class),
+                eq("채팅방이 삭제되었어."),
+                eq("/chat"),
+                eq(8)
+        );
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<WebSocketNotification> notification =
+                ArgumentCaptor.forClass(WebSocketNotification.class);
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("1"), eq("/queue/chat-notifications"), notification.capture());
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("1"), eq("/queue/chat-updates"), any(WebSocketNotification.class));
+        assertEquals("ROOM_DELETED", notification.getValue().getType());
+    }
+
+    @Test
+    void transientSocketFailureLeavesDurableNotificationPendingWithoutFailingEvent() {
+        DomainNotificationEventListener listener = new DomainNotificationEventListener(
+                messagingTemplate,
+                redisSessionService,
+                offlineNotificationService,
+                new ObjectMapper()
+        );
+        OfflineNotification saved = new OfflineNotification();
+        saved.setId(42L);
+        when(offlineNotificationService.saveOfflineNotification(
+                eq(1L),
+                eq(OfflineNotification.NotificationType.ROOM_DELETED),
+                any(String.class),
+                any(String.class),
+                any(String.class),
+                any(Integer.class)
+        )).thenReturn(saved);
+        when(redisSessionService.isUserOnline("1")).thenReturn(true);
+        doThrow(new IllegalStateException("socket unavailable"))
+                .when(messagingTemplate)
+                .convertAndSendToUser(
+                        eq("1"), eq("/queue/chat-notifications"), any(WebSocketNotification.class));
+
+        assertDoesNotThrow(() -> listener.onChatRoomDeleted(
+                ChatRoomDeletedEvent.create("room-1", List.of(1L))));
+
+        verify(offlineNotificationService, never()).markAsDelivered(42L);
+    }
+}

--- a/src/test/java/com/talkwithneighbors/outbox/DomainEventSerializerTest.java
+++ b/src/test/java/com/talkwithneighbors/outbox/DomainEventSerializerTest.java
@@ -1,0 +1,26 @@
+package com.talkwithneighbors.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.talkwithneighbors.domain.event.ChatRoomDeletedEvent;
+import com.talkwithneighbors.domain.event.DomainEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class DomainEventSerializerTest {
+    @Test
+    void deserializesDurableChatRoomDeletedEvent() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        ChatRoomDeletedEvent original = ChatRoomDeletedEvent.create("room-1", List.of(1L, 2L));
+        DomainEventSerializer serializer = new DomainEventSerializer(objectMapper);
+
+        DomainEvent restored = serializer.deserialize(
+                original.eventType(), objectMapper.writeValueAsString(original));
+
+        ChatRoomDeletedEvent event = assertInstanceOf(ChatRoomDeletedEvent.class, restored);
+        assertEquals(original, event);
+    }
+}

--- a/src/test/java/com/talkwithneighbors/outbox/OutboxRelayTest.java
+++ b/src/test/java/com/talkwithneighbors/outbox/OutboxRelayTest.java
@@ -1,0 +1,31 @@
+package com.talkwithneighbors.outbox;
+
+import com.talkwithneighbors.repository.OutboxEventRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxRelayTest {
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private OutboxEventProcessor outboxEventProcessor;
+
+    @Test
+    void immediateDeliveryFailureDoesNotEscapeAfterTheOriginatingCommit() {
+        OutboxRelay relay = new OutboxRelay(outboxEventRepository, outboxEventProcessor);
+        doThrow(new IllegalStateException("temporary failure"))
+                .when(outboxEventProcessor).process("event-1");
+
+        assertDoesNotThrow(() -> relay.deliverAfterCommit(new OutboxEventStored("event-1")));
+
+        verify(outboxEventProcessor).process("event-1");
+    }
+}

--- a/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
@@ -8,6 +8,7 @@ import com.talkwithneighbors.entity.Message;
 import com.talkwithneighbors.entity.MessageAttachment;
 import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.exception.ChatException;
+import com.talkwithneighbors.config.TestConfig;
 import com.talkwithneighbors.outbox.DomainEventPublisher;
 import com.talkwithneighbors.service.ChatService;
 import com.talkwithneighbors.service.NotificationService;
@@ -42,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag("mysql")
 @ActiveProfiles("mysql-it")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({ChatServiceImpl.class, ChatRoomDeletionRepository.class})
+@Import({ChatServiceImpl.class, ChatRoomDeletionRepository.class, TestConfig.class})
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 class ChatRoomDeletionMySqlIntegrationTest {
     @Autowired

--- a/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.talkwithneighbors.repository;
+
+import com.talkwithneighbors.entity.ChatAttachmentType;
+import com.talkwithneighbors.entity.ChatRoom;
+import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.entity.MeetupWaitlistEntry;
+import com.talkwithneighbors.entity.Message;
+import com.talkwithneighbors.entity.MessageAttachment;
+import com.talkwithneighbors.entity.User;
+import com.talkwithneighbors.exception.ChatException;
+import com.talkwithneighbors.outbox.DomainEventPublisher;
+import com.talkwithneighbors.service.ChatService;
+import com.talkwithneighbors.service.NotificationService;
+import com.talkwithneighbors.service.impl.ChatServiceImpl;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+@Tag("mysql")
+@ActiveProfiles("mysql-it")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({ChatServiceImpl.class, ChatRoomDeletionRepository.class})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class ChatRoomDeletionMySqlIntegrationTest {
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Autowired
+    private MeetupWaitlistRepository meetupWaitlistRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private DomainEventPublisher domainEventPublisher;
+
+    @Test
+    void deletesOneToOneRoomAfterMessageWasSoftDeletedAndReadByBothUsers() {
+        Fixture fixture = createFixture(ChatRoomType.ONE_ON_ONE, true, false);
+
+        assertDoesNotThrow(() -> chatService.deleteRoom(fixture.roomId()));
+
+        assertRoomGraphDeleted(fixture);
+        ChatException secondDelete = assertThrows(
+                ChatException.class,
+                () -> chatService.deleteRoom(fixture.roomId())
+        );
+        assertEquals(HttpStatus.NOT_FOUND, secondDelete.getStatus());
+    }
+
+    @Test
+    void deletesGroupRoomWithAttachmentInterestTagAndWaitlist() {
+        Fixture fixture = createFixture(ChatRoomType.GROUP, false, true);
+
+        assertDoesNotThrow(() -> chatService.deleteRoom(fixture.roomId()));
+
+        assertRoomGraphDeleted(fixture);
+    }
+
+    private Fixture createFixture(
+            ChatRoomType type,
+            boolean softDeletedMessage,
+            boolean includeWaitlist
+    ) {
+        Fixture fixture = transactionTemplate.execute(status -> {
+            String suffix = UUID.randomUUID().toString().replace("-", "");
+            User owner = userRepository.save(user("owner-" + suffix));
+            User peer = userRepository.save(user("peer-" + suffix));
+
+            ChatRoom room = new ChatRoom();
+            room.setId("room-" + suffix);
+            room.setName("MySQL deletion regression");
+            room.setType(type);
+            room.setCreator(owner);
+            room.setParticipants(new HashSet<>(List.of(owner, peer)));
+            room.setInterestTags(new ArrayList<>(List.of("database")));
+            room = chatRoomRepository.saveAndFlush(room);
+
+            Message message = new Message();
+            message.setId("message-" + suffix);
+            message.setChatRoom(room);
+            message.setSender(owner);
+            message.setContent(softDeletedMessage ? "" : "attachment message");
+            message.setType(softDeletedMessage
+                    ? Message.MessageType.SYSTEM
+                    : Message.MessageType.IMAGE);
+            message.setDeleted(softDeletedMessage);
+            if (softDeletedMessage) {
+                message.setDeletedAt(LocalDateTime.now());
+            } else {
+                message.setAttachments(new ArrayList<>(List.of(new MessageAttachment(
+                        "/api/media/chat/image.webp",
+                        "/api/media/chat/image-thumbnail.webp",
+                        ChatAttachmentType.IMAGE,
+                        "image/webp",
+                        "image.webp",
+                        128L,
+                        16,
+                        16,
+                        null
+                ))));
+            }
+            message.setReadByUsers(new HashSet<>(List.of(owner.getId(), peer.getId())));
+            messageRepository.saveAndFlush(message);
+
+            if (includeWaitlist) {
+                meetupWaitlistRepository.saveAndFlush(new MeetupWaitlistEntry(room, peer));
+            }
+
+            entityManager.flush();
+            entityManager.clear();
+            return new Fixture(room.getId(), message.getId(), owner.getId(), peer.getId());
+        });
+
+        assertNotNull(fixture);
+        return fixture;
+    }
+
+    private User user(String username) {
+        return User.builder()
+                .email(username + "@example.invalid")
+                .username(username)
+                .password("test-password-hash")
+                .latitude(37.5)
+                .longitude(127.0)
+                .address("Seoul")
+                .build();
+    }
+
+    private void assertRoomGraphDeleted(Fixture fixture) {
+        assertCount(0, "SELECT COUNT(*) FROM chat_rooms WHERE id = ?", fixture.roomId());
+        assertCount(0, "SELECT COUNT(*) FROM messages WHERE chat_room_id = ?", fixture.roomId());
+        assertCount(0, "SELECT COUNT(*) FROM message_read_by WHERE message_id = ?", fixture.messageId());
+        assertCount(0, "SELECT COUNT(*) FROM message_attachments WHERE message_id = ?", fixture.messageId());
+        assertCount(0, "SELECT COUNT(*) FROM chat_room_participants WHERE chat_room_id = ?", fixture.roomId());
+        assertCount(0, "SELECT COUNT(*) FROM chat_room_interest_tags WHERE chat_room_id = ?", fixture.roomId());
+        assertCount(0, "SELECT COUNT(*) FROM meetup_waitlist WHERE room_id = ?", fixture.roomId());
+        assertCount(1, "SELECT COUNT(*) FROM users WHERE id = ?", fixture.ownerId());
+        assertCount(1, "SELECT COUNT(*) FROM users WHERE id = ?", fixture.peerId());
+    }
+
+    private void assertCount(int expected, String sql, Object parameter) {
+        Integer actual = jdbcTemplate.queryForObject(sql, Integer.class, parameter);
+        assertEquals(expected, actual);
+    }
+
+    private record Fixture(String roomId, String messageId, Long ownerId, Long peerId) {
+    }
+}

--- a/src/test/java/com/talkwithneighbors/service/impl/ChatServiceImplTest.java
+++ b/src/test/java/com/talkwithneighbors/service/impl/ChatServiceImplTest.java
@@ -5,7 +5,11 @@ import com.talkwithneighbors.entity.ChatRoom;
 import com.talkwithneighbors.entity.Message;
 import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.domain.event.ChatRoomDeletedEvent;
+import com.talkwithneighbors.domain.event.MediaFilesDeletedEvent;
 import com.talkwithneighbors.exception.ChatException;
+import com.talkwithneighbors.outbox.DomainEventPublisher;
+import com.talkwithneighbors.repository.ChatRoomDeletionRepository;
 import com.talkwithneighbors.repository.ChatRoomRepository;
 import com.talkwithneighbors.repository.MessageRepository;
 import com.talkwithneighbors.repository.UserRepository;
@@ -18,7 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate; // Though not directly used by getMessagesByRoomId
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
@@ -48,7 +52,13 @@ class ChatServiceImplTest {
     private UserRepository userRepository;
 
     @Mock
-    private SimpMessagingTemplate messagingTemplate; // Dependency of ChatServiceImpl
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private ChatRoomDeletionRepository chatRoomDeletionRepository;
+
+    @Mock
+    private DomainEventPublisher domainEventPublisher;
 
     @InjectMocks
     private ChatServiceImpl chatService;
@@ -242,5 +252,65 @@ class ChatServiceImplTest {
         verify(messageRepository).save(messageCaptor.capture());
         Message savedMessage = messageCaptor.getValue();
         assertTrue(savedMessage.getReadByUsers().contains(testUser.getId()));
+    }
+
+    @Test
+    void deleteRoomDeletesTheCompleteGraphAndPublishesAfterCommitEvents() {
+        String roomId = room.getId();
+        List<String> mediaUrls = List.of(
+                "/api/media/chat/image.webp",
+                "/api/media/chat/image-thumbnail.webp"
+        );
+        ChatRoomDeletionRepository.ChatRoomDeletionResult deletionResult =
+                new ChatRoomDeletionRepository.ChatRoomDeletionResult(0, 2, 1, 1, 0, 2, 1);
+
+        when(chatRoomRepository.findByIdForUpdate(roomId)).thenReturn(Optional.of(room));
+        when(chatRoomDeletionRepository.findMediaUrlsByRoomId(roomId)).thenReturn(mediaUrls);
+        when(chatRoomDeletionRepository.deleteByRoomId(roomId)).thenReturn(deletionResult);
+
+        chatService.deleteRoom(roomId);
+
+        verify(chatRoomDeletionRepository).deleteByRoomId(roomId);
+        ArgumentCaptor<MediaFilesDeletedEvent> mediaEvent =
+                ArgumentCaptor.forClass(MediaFilesDeletedEvent.class);
+        verify(applicationEventPublisher).publishEvent(mediaEvent.capture());
+        assertEquals(mediaUrls, mediaEvent.getValue().mediaUrls());
+
+        ArgumentCaptor<ChatRoomDeletedEvent> roomEvent =
+                ArgumentCaptor.forClass(ChatRoomDeletedEvent.class);
+        verify(domainEventPublisher).publish(roomEvent.capture());
+        assertEquals(roomId, roomEvent.getValue().roomId());
+        assertEquals(Set.of(creator.getId(), participant.getId()),
+                Set.copyOf(roomEvent.getValue().participantIds()));
+    }
+
+    @Test
+    void deleteRoomMissingRoomReturnsNotFoundWithoutDeletingAnything() {
+        when(chatRoomRepository.findByIdForUpdate(testRoomId)).thenReturn(Optional.empty());
+
+        ChatException exception = assertThrows(
+                ChatException.class,
+                () -> chatService.deleteRoom(testRoomId)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatus());
+        verifyNoInteractions(chatRoomDeletionRepository, applicationEventPublisher, domainEventPublisher);
+    }
+
+    @Test
+    void deleteRoomDatabaseFailureDoesNotPublishDeletionEvents() {
+        String roomId = room.getId();
+        when(chatRoomRepository.findByIdForUpdate(roomId)).thenReturn(Optional.of(room));
+        when(chatRoomDeletionRepository.findMediaUrlsByRoomId(roomId)).thenReturn(List.of());
+        when(chatRoomDeletionRepository.deleteByRoomId(roomId))
+                .thenThrow(new IllegalStateException("constraint failure"));
+
+        ChatException exception = assertThrows(
+                ChatException.class,
+                () -> chatService.deleteRoom(roomId)
+        );
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
+        verifyNoInteractions(applicationEventPublisher, domainEventPublisher);
     }
 }

--- a/src/test/resources/application-mysql-it.yml
+++ b/src/test/resources/application-mysql-it.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: talkWithNeighbors-mysql-it
+  datasource:
+    url: ${MYSQL_IT_URL}
+    username: ${MYSQL_IT_USERNAME}
+    password: ${MYSQL_IT_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      minimum-idle: 0
+      maximum-pool-size: 4
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    show-sql: false
+  session:
+    store-type: none
+  data:
+    redis:
+      repositories:
+        enabled: false
+
+app:
+  media:
+    storage-directory: ${java.io.tmpdir}/talk-with-neighbors-mysql-it-uploads


### PR DESCRIPTION
## Summary
- delete chat-room-owned rows in explicit foreign-key order under a pessimistic lock
- publish durable `CHAT_ROOM_DELETED` notifications through the existing Outbox relay after commit
- atomically clear stale Redis room presence and keep offline notifications pending on socket failure
- return a real 404 for missing rooms
- run commit-level deletion regressions against MySQL 8.4 in CI and image quality gates

## Verification
- local full backend test suite passed
- local `bootJar` passed
- CI adds real MySQL cases for soft-deleted/read messages and attachment/tag/waitlist room graphs

The PR should only be merged after all required checks, including the new MySQL integration test and container scan, are green.