### PR TITLE
Patch managed Jackson and Logback vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,9 @@ plugins {
 group = 'com.talkwithneighbors'
 version = '0.0.1-SNAPSHOT'
 
+ext['jackson-bom.version'] = '2.21.5'
+ext['logback.version'] = '1.5.35'
+
 java {
 	sourceCompatibility = '17'
 }


### PR DESCRIPTION
## Summary
- override the Spring-managed Jackson BOM from 2.21.4 to 2.21.5
- align Logback core/classic from 1.5.34 to 1.5.35
- address Dependabot alerts #81 (CVE-2026-54515) and #79 (CVE-2026-10532)

## Risk assessment
- no vulnerable Jackson case-insensitive deserialization configuration is present
- no vulnerable Logback socket server/appender is used
- this is a coherent BOM/managed-version patch with no application API changes
- alert #80 (`commons-lang3`) remains build-tool-only through the latest Spring Boot 3.5 Gradle plugin; no fake runtime dependency is added

## Verification
- `runtimeClasspath` resolves all Jackson modules to 2.21.5
- `runtimeClasspath` resolves Logback core/classic to 1.5.35
- `./gradlew.bat clean test bootJar --no-daemon` passes locally
- PR CI will run MySQL 8.4 integration, production image scan, and MySQL/Redis container smoke