### PR TITLE
Fix canonical HTTPS redirect and deployment smoke test

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -521,7 +521,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          read -r redirect_status redirect_url < <(curl --show-error --silent --output /dev/null --max-redirs 0 --write-out '%{http_code} %{redirect_url}' "http://${PUBLIC_HOST}/healthz")
+          redirect_result="$(curl --show-error --silent --output /dev/null --max-redirs 0 --write-out '%{http_code} %{redirect_url}' "http://${PUBLIC_HOST}/healthz")"
+          read -r redirect_status redirect_url <<<"$redirect_result"
           [[ "$redirect_status" == "301" || "$redirect_status" == "308" ]] || { echo "HTTP did not return a permanent HTTPS redirect" >&2; exit 1; }
           [[ "$redirect_url" == "$PUBLIC_ORIGIN/healthz" ]] || { echo "HTTP redirect target was not the canonical HTTPS origin" >&2; exit 1; }
           health_status="$(curl --fail --show-error --silent --retry 12 --retry-all-errors --retry-delay 5 --output "$RUNNER_TEMP/healthz.txt" --write-out '%{http_code}' "$PUBLIC_ORIGIN/healthz")"

--- a/deploy/k8s/deploy-on-node.sh
+++ b/deploy/k8s/deploy-on-node.sh
@@ -54,7 +54,7 @@ wait_for_traefik_https_config() {
       ($container.args // []) as $args |
       ($args | index("--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json")) != null and
       ($args | index("--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web")) != null and
-      ($args | index("--entrypoints.web.http.redirections.entrypoint.to=websecure")) != null and
+      ($args | index("--entrypoints.web.http.redirections.entrypoint.to=:443")) != null and
       ($args | index("--entrypoints.web.http.redirections.entrypoint.scheme=https")) != null and
       (.spec.template.spec.securityContext.fsGroup == 65532)
     ' <<<"$deployment_json" >/dev/null; then

--- a/deploy/k8s/tests/test-k3s-network-reinitialize.sh
+++ b/deploy/k8s/tests/test-k3s-network-reinitialize.sh
@@ -155,6 +155,8 @@ done
 tar -xOzf "$temporary/bundle.tgz" ./traefik-config.yaml > "$temporary/traefik-with-email.yaml"
 grep -Fq -- '--certificatesresolvers.letsencrypt.acme.email=portfolio-owner@example.com' \
   "$temporary/traefik-with-email.yaml" || fail "Configured ACME email was not rendered"
+grep -Fq -- '--entrypoints.web.http.redirections.entrypoint.to=:443' \
+  "$temporary/traefik-with-email.yaml" || fail "HTTP redirect does not target the canonical external HTTPS port"
 ! grep -Fq 'REPLACE_ACME_EMAIL_ARGUMENT' "$temporary/traefik-with-email.yaml" || \
   fail "The ACME email placeholder leaked into the rendered bundle"
 

--- a/deploy/k8s/traefik-config.yaml
+++ b/deploy/k8s/traefik-config.yaml
@@ -11,7 +11,7 @@ spec:
       REPLACE_ACME_EMAIL_ARGUMENT
       - "--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
-      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.to=:443"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
     persistence:


### PR DESCRIPTION
## What changed
- redirect HTTP traffic to the public `:443` port instead of Traefik's internal `websecure` port
- parse curl redirect metadata through a here-string so Bash `read` does not fail on EOF under `set -e`
- add a bundle regression assertion for the canonical HTTPS redirect port

## Root cause
k3s exposes Traefik's internal websecure entrypoint on port 8443, so redirecting by entrypoint name produced a public `https://…:8443` location. The smoke test also used `read` on curl output without a trailing newline, which exits non-zero at EOF before its assertions run.

## Impact
HTTP now redirects to the canonical `https://talk-with-neighbors.duckdns.org/...` URL, while the strict deployment smoke test reports the real redirect contract.

## Validation
- actionlint passed
- ShellCheck v0.11.0 passed for deployment scripts
- deployment ordering test passed
- k3s network migration and bundle guard test passed
- live HTTPS `/healthz` already returns `200 ok` with certificate verification