### PR TITLE
Fix Kakao OIDC verified email lookup

### DIFF
--- a/src/main/java/com/talkwithneighbors/auth/oauth/OAuthClientConfig.java
+++ b/src/main/java/com/talkwithneighbors/auth/oauth/OAuthClientConfig.java
@@ -10,16 +10,22 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 
 @Configuration
 @EnableConfigurationProperties(OAuthProperties.class)
 public class OAuthClientConfig {
+    private static final Set<String> STANDARD_USER_INFO_SCOPES =
+            Set.of("profile", "email", "address", "phone");
+
     @Bean
     FilterRegistrationBean<OAuthReturnToCaptureFilter> oauthReturnToContainerRegistration(
             OAuthReturnToCaptureFilter filter) {
@@ -35,6 +41,27 @@ public class OAuthClientConfig {
         if (properties.googleEnabled()) registrations.add(google(properties));
         if (properties.kakaoEnabled()) registrations.add(kakao(properties));
         return new InMemoryClientRegistrationRepository(registrations);
+    }
+
+    @Bean
+    OidcUserService oidcUserService() {
+        OidcUserService service = new OidcUserService();
+        service.setRetrieveUserInfo(request -> {
+            ClientRegistration registration = request.getClientRegistration();
+            String userInfoUri = registration.getProviderDetails().getUserInfoEndpoint().getUri();
+            if (!AuthorizationGrantType.AUTHORIZATION_CODE.equals(registration.getAuthorizationGrantType())
+                    || userInfoUri == null || userInfoUri.isBlank()) {
+                return false;
+            }
+            if ("kakao".equals(registration.getRegistrationId())) {
+                // Kakao grants account_email instead of the standard email scope.
+                // email_verified is exposed by Kakao UserInfo, not its ID token.
+                return true;
+            }
+            Set<String> scopes = request.getAccessToken().getScopes();
+            return scopes.isEmpty() || !Collections.disjoint(scopes, STANDARD_USER_INFO_SCOPES);
+        });
+        return service;
     }
 
     private ClientRegistration google(OAuthProperties properties) {

--- a/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -33,6 +34,7 @@ public class SecurityConfig {
     private final OAuthLoginFailureHandler oauthFailureHandler;
     private final TransientAuthorizedClientRepository authorizedClients;
     private final OAuthReturnToCaptureFilter oauthReturnToCaptureFilter;
+    private final OidcUserService oidcUserService;
 
     @Bean
     public static PasswordEncoder passwordEncoder() {
@@ -81,6 +83,7 @@ public class SecurityConfig {
             http.oauth2Login(oauth -> oauth
                     .authorizationEndpoint(endpoint -> endpoint.baseUri("/api/oauth2/authorization"))
                     .redirectionEndpoint(endpoint -> endpoint.baseUri("/api/login/oauth2/code/*"))
+                    .userInfoEndpoint(endpoint -> endpoint.oidcUserService(oidcUserService))
                     .authorizedClientRepository(authorizedClients)
                     .successHandler(oauthSuccessHandler)
                     .failureHandler(oauthFailureHandler));

--- a/src/test/java/com/talkwithneighbors/auth/oauth/OAuthAuthFlowTest.java
+++ b/src/test/java/com/talkwithneighbors/auth/oauth/OAuthAuthFlowTest.java
@@ -13,6 +13,9 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
 import java.time.Instant;
@@ -80,6 +83,69 @@ class OAuthAuthFlowTest {
         assertEquals("https://talk.example/auth/callback?status=error&returnTo=%2Ffeed&error=ACCOUNT_LINK_REQUIRED",
                 response.getRedirectedUrl());
         assertTrue(session.isInvalid());
+    }
+
+    @Test
+    void kakaoUserInfoVerifiedEmailReachesIdentityResolution() throws Exception {
+        OAuthIdentityService identities = mock(OAuthIdentityService.class);
+        SessionIssuer sessions = mock(SessionIssuer.class);
+        SessionCookieFactory cookies = mock(SessionCookieFactory.class);
+        OAuthProperties properties = new OAuthProperties();
+        properties.setFrontendBaseUrl("https://talk.example");
+        OAuthLoginSuccessHandler handler = new OAuthLoginSuccessHandler(
+                identities, sessions, cookies, properties, true);
+        when(identities.resolveOrCreate(
+                OAuthProvider.KAKAO, "kakao-subject", "dayun@example.com", true))
+                .thenThrow(new OAuthLoginException(
+                        "ACCOUNT_LINK_REQUIRED", "link required", HttpStatus.CONFLICT));
+
+        Instant now = Instant.now();
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token",
+                now,
+                now.plusSeconds(300),
+                Map.of(
+                        "iss", "https://kauth.kakao.com",
+                        "sub", "kakao-subject",
+                        "aud", List.of("client-id"),
+                        "email", "dayun@example.com"));
+        OidcUserInfo userInfo = new OidcUserInfo(Map.of(
+                "sub", "kakao-subject",
+                "email", "dayun@example.com",
+                "email_verified", true));
+        DefaultOidcUser principal = new DefaultOidcUser(
+                List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, userInfo, "sub");
+        OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(
+                principal, principal.getAuthorities(), "kakao");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpSession session = (MockHttpSession) request.getSession();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        verify(identities).resolveOrCreate(
+                OAuthProvider.KAKAO, "kakao-subject", "dayun@example.com", true);
+        assertTrue(session.isInvalid());
+        assertEquals(
+                "https://talk.example/auth/callback?status=error&returnTo=%2F&error=ACCOUNT_LINK_REQUIRED",
+                response.getRedirectedUrl());
+    }
+
+    @Test
+    void newIdentityStillRejectsEmailWithoutProviderVerification() {
+        UserIdentityRepository identities = mock(UserIdentityRepository.class);
+        UserRepository users = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        OAuthIdentityService service = new OAuthIdentityService(identities, users, encoder);
+        when(identities.findByProviderAndProviderSubject(OAuthProvider.KAKAO, "kakao-subject"))
+                .thenReturn(Optional.empty());
+
+        OAuthLoginException exception = assertThrows(OAuthLoginException.class, () ->
+                service.resolveOrCreate(
+                        OAuthProvider.KAKAO, "kakao-subject", "dayun@example.com", false));
+
+        assertEquals("PROVIDER_EMAIL_REQUIRED", exception.getCode());
+        verifyNoInteractions(users, encoder);
     }
 
     @Test

--- a/src/test/java/com/talkwithneighbors/auth/oauth/OAuthOidcUserServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/auth/oauth/OAuthOidcUserServiceTest.java
@@ -1,0 +1,104 @@
+package com.talkwithneighbors.auth.oauth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class OAuthOidcUserServiceTest {
+    @Test
+    void kakaoRetrievesUserInfoForItsNonStandardEmailScope() {
+        OidcUserService service = new OAuthClientConfig().oidcUserService();
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> userInfoService = userInfoService();
+        service.setOauth2UserService(userInfoService);
+        when(userInfoService.loadUser(any())).thenReturn(new DefaultOAuth2User(
+                List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                Map.of(
+                        "sub", "kakao-subject",
+                        "email", "dayun@example.com",
+                        "email_verified", true),
+                "sub"));
+
+        OidcUser user = service.loadUser(request(
+                "kakao", Set.of("openid", "account_email", "profile_nickname")));
+
+        verify(userInfoService).loadUser(any(OAuth2UserRequest.class));
+        assertEquals("dayun@example.com", user.getAttribute("email"));
+        assertEquals(Boolean.TRUE, user.getAttribute("email_verified"));
+    }
+
+    @Test
+    void standardProviderKeepsTheFrameworkScopeBoundary() {
+        OidcUserService service = new OAuthClientConfig().oidcUserService();
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> userInfoService = userInfoService();
+        service.setOauth2UserService(userInfoService);
+
+        OidcUser user = service.loadUser(request("google", Set.of("openid")));
+
+        verifyNoInteractions(userInfoService);
+        assertNull(user.getAttribute("email_verified"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private OAuth2UserService<OAuth2UserRequest, OAuth2User> userInfoService() {
+        return mock(OAuth2UserService.class);
+    }
+
+    private OidcUserRequest request(String registrationId, Set<String> scopes) {
+        Instant now = Instant.now();
+        ClientRegistration registration = ClientRegistration.withRegistrationId(registrationId)
+                .clientId("client-id")
+                .clientSecret("client-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://talk.example/api/login/oauth2/code/{registrationId}")
+                .scope("openid")
+                .authorizationUri("https://provider.example/authorize")
+                .tokenUri("https://provider.example/token")
+                .jwkSetUri("https://provider.example/jwks")
+                .issuerUri("https://provider.example")
+                .userInfoUri("https://provider.example/userinfo")
+                .userNameAttributeName("sub")
+                .clientName(registrationId)
+                .build();
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                now,
+                now.plusSeconds(300),
+                scopes);
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token",
+                now,
+                now.plusSeconds(300),
+                Map.of(
+                        "iss", "https://provider.example",
+                        "sub", "kakao-subject",
+                        "aud", List.of("client-id"),
+                        "email", "dayun@example.com"));
+        return new OidcUserRequest(registration, accessToken, idToken);
+    }
+}


### PR DESCRIPTION
## What changed

- register a provider-aware `OidcUserService`
- force Kakao OIDC UserInfo retrieval for Kakao's non-standard `account_email` scope
- keep the existing standard-scope boundary for Google and future standard providers
- wire the service into Spring Security's OAuth login flow
- add regression coverage for Kakao UserInfo claim merging and unverified-email rejection

## Root cause

Spring Security's default OIDC UserInfo lookup only recognizes the standard `profile`, `email`, `address`, and `phone` access-token scopes. Kakao grants `account_email`, so UserInfo was skipped. Kakao's ID token can contain `email` but does not contain `email_verified`; the backend therefore rejected a correctly consented login as `PROVIDER_EMAIL_REQUIRED`.

## User impact

Users who consent to Kakao account email can complete first-time sign-in while the backend still requires Kakao's explicit `email_verified=true` signal. No verified-email checks were weakened.

## Validation

- targeted OAuth regression tests: passed
- full backend suite: 219 tests, 0 failures
- Spring Boot `bootJar`: passed
- independent patch review: no P0-P3 findings