### PR TITLE
Require explicit social nickname setup

### DIFF
--- a/src/main/java/com/talkwithneighbors/auth/nickname/NicknameException.java
+++ b/src/main/java/com/talkwithneighbors/auth/nickname/NicknameException.java
@@ -1,0 +1,15 @@
+package com.talkwithneighbors.auth.nickname;
+
+import com.talkwithneighbors.exception.AuthException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NicknameException extends AuthException {
+    private final String code;
+
+    public NicknameException(String code, String message, HttpStatus status) {
+        super(message, status);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/talkwithneighbors/auth/nickname/NicknameExceptionHandler.java
+++ b/src/main/java/com/talkwithneighbors/auth/nickname/NicknameExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.talkwithneighbors.auth.nickname;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class NicknameExceptionHandler {
+    @ExceptionHandler(NicknameException.class)
+    ResponseEntity<ErrorResponse> handle(NicknameException exception) {
+        return ResponseEntity.status(exception.getStatus())
+                .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    public record ErrorResponse(String code, String message) {}
+}

--- a/src/main/java/com/talkwithneighbors/auth/oauth/OAuthIdentityService.java
+++ b/src/main/java/com/talkwithneighbors/auth/oauth/OAuthIdentityService.java
@@ -13,6 +13,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 @Service
 public class OAuthIdentityService {
@@ -38,8 +39,16 @@ public class OAuthIdentityService {
         Instant now = Instant.now();
         UserIdentity existing = identities.findByProviderAndProviderSubject(provider, subject).orElse(null);
         if (existing != null) {
+            User user = existing.getUser();
+            if (!existing.isNicknameSetupAssessed()) {
+                if (!Boolean.TRUE.equals(user.getNicknameSetupRequired())
+                        && isGeneratedUsername(provider, subject, user.getUsername())) {
+                    user.setNicknameSetupRequired(true);
+                }
+                existing.markNicknameSetupAssessed();
+            }
             existing.recordLogin(now);
-            return existing.getUser();
+            return user;
         }
         if (!emailVerified || rawEmail == null || rawEmail.isBlank()) {
             throw new OAuthLoginException(
@@ -64,6 +73,7 @@ public class OAuthIdentityService {
         user.setPassword(passwordEncoder.encode(Base64.getUrlEncoder().withoutPadding().encodeToString(passwordBytes)));
         user.setAccountType(UserAccountType.MEMBER);
         user.setPasswordLoginEnabled(false);
+        user.setNicknameSetupRequired(true);
         user.setAge(0);
         user.setGender("");
         user.setLatitude(0.0);
@@ -75,13 +85,23 @@ public class OAuthIdentityService {
     }
 
     private String uniqueUsername(OAuthProvider provider, String subject) {
-        String compact = subject.replaceAll("[^A-Za-z0-9]", "");
-        if (compact.isBlank()) compact = Integer.toUnsignedString(subject.hashCode(), 36);
-        compact = compact.substring(0, Math.min(12, compact.length())).toLowerCase(Locale.ROOT);
-        String base = provider.name().toLowerCase(Locale.ROOT) + "_" + compact;
+        String base = usernameBase(provider, subject);
         String candidate = base;
         int suffix = 1;
         while (users.existsByUsername(candidate)) candidate = base + "_" + suffix++;
         return candidate;
+    }
+
+    static boolean isGeneratedUsername(OAuthProvider provider, String subject, String username) {
+        if (username == null) return false;
+        String base = usernameBase(provider, subject);
+        return username.equals(base) || username.matches(Pattern.quote(base) + "_[1-9][0-9]*");
+    }
+
+    private static String usernameBase(OAuthProvider provider, String subject) {
+        String compact = subject.replaceAll("[^A-Za-z0-9]", "");
+        if (compact.isBlank()) compact = Integer.toUnsignedString(subject.hashCode(), 36);
+        compact = compact.substring(0, Math.min(12, compact.length())).toLowerCase(Locale.ROOT);
+        return provider.name().toLowerCase(Locale.ROOT) + "_" + compact;
     }
 }

--- a/src/main/java/com/talkwithneighbors/auth/oauth/OAuthNicknameSetupBackfill.java
+++ b/src/main/java/com/talkwithneighbors/auth/oauth/OAuthNicknameSetupBackfill.java
@@ -1,0 +1,38 @@
+package com.talkwithneighbors.auth.oauth;
+
+import com.talkwithneighbors.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthNicknameSetupBackfill implements ApplicationRunner {
+    private final UserIdentityRepository identities;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments arguments) {
+        int updated = 0;
+        for (UserIdentity identity : identities.findAll()) {
+            if (identity.isNicknameSetupAssessed()) {
+                continue;
+            }
+            User user = identity.getUser();
+            if (!Boolean.TRUE.equals(user.getNicknameSetupRequired())
+                    && OAuthIdentityService.isGeneratedUsername(
+                            identity.getProvider(), identity.getProviderSubject(), user.getUsername())) {
+                user.setNicknameSetupRequired(true);
+                updated++;
+            }
+            identity.markNicknameSetupAssessed();
+        }
+        if (updated > 0) {
+            log.info("Marked {} existing OAuth account(s) for nickname setup.", updated);
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/auth/oauth/UserIdentity.java
+++ b/src/main/java/com/talkwithneighbors/auth/oauth/UserIdentity.java
@@ -53,6 +53,15 @@ public class UserIdentity {
     @Column(name = "last_login_at", nullable = false)
     private Instant lastLoginAt;
 
+    /**
+     * Durable marker for the one-time legacy nickname assessment. Without this
+     * marker a user-selected nickname that resembles the old generated format
+     * could be incorrectly challenged again on every login or restart.
+     */
+    @Column(name = "nickname_setup_assessed", nullable = false,
+            columnDefinition = "boolean default false")
+    private boolean nicknameSetupAssessed;
+
     public static UserIdentity create(
             OAuthProvider provider, String subject, User user, String email, Instant now) {
         UserIdentity identity = new UserIdentity();
@@ -63,10 +72,15 @@ public class UserIdentity {
         identity.providerEmailVerified = true;
         identity.createdAt = now;
         identity.lastLoginAt = now;
+        identity.nicknameSetupAssessed = true;
         return identity;
     }
 
     public void recordLogin(Instant now) {
         this.lastLoginAt = now;
+    }
+
+    public void markNicknameSetupAssessed() {
+        this.nicknameSetupAssessed = true;
     }
 }

--- a/src/main/java/com/talkwithneighbors/controller/AuthController.java
+++ b/src/main/java/com/talkwithneighbors/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.talkwithneighbors.controller;
 import com.talkwithneighbors.dto.UserDto;
 import com.talkwithneighbors.dto.auth.LoginRequestDto;
 import com.talkwithneighbors.dto.auth.RegisterRequestDto;
+import com.talkwithneighbors.dto.auth.UpdateNicknameRequest;
 import com.talkwithneighbors.security.UserSession;
 import com.talkwithneighbors.service.AuthService;
 import com.talkwithneighbors.service.AuthService.AuthResponse;
@@ -97,6 +98,14 @@ public class AuthController {
         String actualSessionId = sessionId.split(",")[0].trim();
         UserDto updatedUser = authService.updateProfile(actualSessionId, request);
         return ResponseEntity.ok(updatedUser);
+    }
+
+    @PutMapping("/profile/nickname")
+    public ResponseEntity<UserDto> updateNickname(
+            @Valid @RequestBody UpdateNicknameRequest request,
+            HttpServletRequest httpRequest) {
+        return ResponseEntity.ok(authService.updateNickname(
+                requireSessionId(httpRequest), request.nickname()));
     }
 
     @PostMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/talkwithneighbors/dto/UserDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/UserDto.java
@@ -21,6 +21,7 @@ public class UserDto {
     private Double longitude;
     private String address;
     private List<String> interests;
+    private boolean nicknameSetupRequired;
     private boolean profileComplete;
     private int profileCompletion;
 
@@ -37,7 +38,9 @@ public class UserDto {
         dto.setLongitude(user.getLongitude());
         dto.setAddress(user.getAddress());
         dto.setInterests(user.getInterests());
-        dto.setProfileComplete(user.isProfileComplete());
+        boolean nicknameSetupRequired = Boolean.TRUE.equals(user.getNicknameSetupRequired());
+        dto.setNicknameSetupRequired(nicknameSetupRequired);
+        dto.setProfileComplete(user.isProfileComplete() && !nicknameSetupRequired);
         int completed = 0;
         if (user.getAge() != null) completed++;
         if (user.getGender() != null && !user.getGender().isBlank()) completed++;

--- a/src/main/java/com/talkwithneighbors/dto/auth/UpdateNicknameRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/auth/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.talkwithneighbors.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank(message = "닉네임을 입력해 주세요.")
+        // Bean Validation counts UTF-16 code units. Allow up to 60 here so the
+        // service can enforce the user-facing 30 Unicode code-point limit.
+        @Size(min = 2, max = 60, message = "닉네임은 2자 이상 30자 이하여야 합니다.")
+        String nickname
+) {}

--- a/src/main/java/com/talkwithneighbors/entity/User.java
+++ b/src/main/java/com/talkwithneighbors/entity/User.java
@@ -69,6 +69,11 @@ public class User {
     @Builder.Default
     private Boolean passwordLoginEnabled = true;
 
+    @Column(name = "nickname_setup_required", nullable = false,
+            columnDefinition = "boolean default false")
+    @Builder.Default
+    private Boolean nicknameSetupRequired = false;
+
     /**
      * 사용자의 프로필 이미지 URL
      */
@@ -186,6 +191,9 @@ public class User {
         }
         if (passwordLoginEnabled == null) {
             passwordLoginEnabled = true;
+        }
+        if (nicknameSetupRequired == null) {
+            nicknameSetupRequired = false;
         }
     }
 }

--- a/src/main/java/com/talkwithneighbors/repository/UserRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/UserRepository.java
@@ -39,6 +39,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     boolean existsByUsername(String username);
 
+    boolean existsByUsernameAndIdNot(String username, Long id);
+
     /**
      * 특정 위치 주변의 사용자들을 조회합니다.
      * Haversine 공식을 사용하여 지구 표면의 거리를 계산합니다.
@@ -102,4 +104,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return 사용자 목록
      */
     List<User> findAllByUsernameIn(List<String> usernames);
-} 
+}

--- a/src/main/java/com/talkwithneighbors/service/AuthService.java
+++ b/src/main/java/com/talkwithneighbors/service/AuthService.java
@@ -7,6 +7,7 @@ import com.talkwithneighbors.domain.event.MediaFilesDeletedEvent;
 import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.entity.UserAccountType;
 import com.talkwithneighbors.auth.email.EmailVerificationService;
+import com.talkwithneighbors.auth.nickname.NicknameException;
 import com.talkwithneighbors.auth.session.SessionIssuer;
 import com.talkwithneighbors.exception.AuthException;
 import com.talkwithneighbors.repository.UserRepository;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -143,6 +145,17 @@ public class AuthService {
     }
 
     @Transactional(rollbackFor = Exception.class)
+    public UserDto updateNickname(String sessionId, String rawNickname) {
+        User user = requireSessionUser(sessionId);
+        boolean changed = applyNickname(user, rawNickname, true);
+        if (!changed) return UserDto.fromEntity(user);
+
+        User updatedUser = saveNicknameChange(user);
+        redisSessionService.updateSession(sessionId, updatedUser.getId(), updatedUser.getUsername());
+        return UserDto.fromEntity(updatedUser);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
     public UserDto updateProfile(String sessionId, UserDto request) {
         UserSession userSession = redisSessionService.getSession(sessionId);
         if (userSession == null) {
@@ -151,7 +164,8 @@ public class AuthService {
         User user = userRepository.findById(userSession.getUserId())
                 .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
-        user.setUsername(request.getUsername());
+        boolean nicknameChanged = request.getUsername() != null
+                && applyNickname(user, request.getUsername(), false);
         user.setAge(request.getAge());
         user.setGender(request.getGender());
         user.setBio(request.getBio());
@@ -161,8 +175,76 @@ public class AuthService {
         user.setAddress(request.getAddress());
         user.setInterests(request.getInterests());
 
-        User updatedUser = userRepository.save(user);
+        User updatedUser = nicknameChanged ? saveNicknameChange(user) : userRepository.save(user);
+        if (nicknameChanged) {
+            redisSessionService.updateSession(sessionId, updatedUser.getId(), updatedUser.getUsername());
+        }
         return UserDto.fromEntity(updatedUser);
+    }
+
+    private User requireSessionUser(String sessionId) {
+        UserSession userSession = redisSessionService.getSession(sessionId);
+        if (userSession == null) {
+            throw new AuthException("세션을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        return userRepository.findById(userSession.getUserId())
+                .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+    }
+
+    private boolean applyNickname(User user, String rawNickname, boolean requireChange) {
+        String nickname = normalizeNickname(rawNickname);
+        if (nickname.equals(user.getUsername())) {
+            if (requireChange && Boolean.TRUE.equals(user.getNicknameSetupRequired())) {
+                throw new NicknameException(
+                        "NICKNAME_CHANGE_REQUIRED",
+                        "자동 생성된 닉네임과 다른 닉네임을 입력해 주세요.",
+                        HttpStatus.BAD_REQUEST);
+            }
+            return false;
+        }
+        if (userRepository.existsByUsernameAndIdNot(nickname, user.getId())) {
+            throw duplicateNickname();
+        }
+        user.setUsername(nickname);
+        user.setNicknameSetupRequired(false);
+        return true;
+    }
+
+    private String normalizeNickname(String rawNickname) {
+        String nickname = rawNickname == null ? "" : rawNickname.strip();
+        int length = nickname.codePointCount(0, nickname.length());
+        boolean invalid = length < 2
+                || length > 30
+                || nickname.codePoints().anyMatch(AuthService::isForbiddenNicknameCodePoint);
+        if (invalid) {
+            throw new NicknameException(
+                    "NICKNAME_INVALID",
+                    "닉네임은 공백 없이 2자 이상 30자 이하로 입력해 주세요.",
+                    HttpStatus.BAD_REQUEST);
+        }
+        return nickname;
+    }
+
+    private static boolean isForbiddenNicknameCodePoint(int codePoint) {
+        return Character.isWhitespace(codePoint)
+                || Character.isSpaceChar(codePoint)
+                || Character.isISOControl(codePoint)
+                || Character.getType(codePoint) == Character.FORMAT;
+    }
+
+    private User saveNicknameChange(User user) {
+        try {
+            return userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException exception) {
+            throw duplicateNickname();
+        }
+    }
+
+    private NicknameException duplicateNickname() {
+        return new NicknameException(
+                "USERNAME_ALREADY_IN_USE",
+                "이미 사용 중인 닉네임이에요.",
+                HttpStatus.CONFLICT);
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/src/test/java/com/talkwithneighbors/auth/oauth/OAuthAuthFlowTest.java
+++ b/src/test/java/com/talkwithneighbors/auth/oauth/OAuthAuthFlowTest.java
@@ -17,6 +17,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -52,6 +53,80 @@ class OAuthAuthFlowTest {
         assertSame(user, service.resolveOrCreate(
                 OAuthProvider.GOOGLE, "stable-sub", "changed@example.com", true));
         verifyNoInteractions(users, encoder);
+    }
+
+    @Test
+    void legacyGeneratedOAuthNicknameIsMarkedForSetupOnNextLogin() {
+        UserIdentityRepository identities = mock(UserIdentityRepository.class);
+        UserRepository users = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        OAuthIdentityService service = new OAuthIdentityService(identities, users, encoder);
+        User user = User.builder()
+                .id(8L)
+                .email("dayun@example.com")
+                .username("kakao_legacysub")
+                .nicknameSetupRequired(false)
+                .build();
+        UserIdentity identity = UserIdentity.create(
+                OAuthProvider.KAKAO, "legacy-sub", user, user.getEmail(), Instant.now());
+        ReflectionTestUtils.setField(identity, "nicknameSetupAssessed", false);
+        when(identities.findByProviderAndProviderSubject(OAuthProvider.KAKAO, "legacy-sub"))
+                .thenReturn(Optional.of(identity));
+
+        assertSame(user, service.resolveOrCreate(
+                OAuthProvider.KAKAO, "legacy-sub", user.getEmail(), true));
+        assertTrue(user.getNicknameSetupRequired());
+        assertTrue(identity.isNicknameSetupAssessed());
+        verifyNoInteractions(users, encoder);
+    }
+
+    @Test
+    void assessedGeneratedShapedNicknameIsNotChallengedAgain() {
+        UserIdentityRepository identities = mock(UserIdentityRepository.class);
+        UserRepository users = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        OAuthIdentityService service = new OAuthIdentityService(identities, users, encoder);
+        User user = User.builder()
+                .id(9L)
+                .email("dayun@example.com")
+                .username("kakao_stablesub_1")
+                .nicknameSetupRequired(false)
+                .build();
+        UserIdentity identity = UserIdentity.create(
+                OAuthProvider.KAKAO, "stable-sub", user, user.getEmail(), Instant.now());
+        when(identities.findByProviderAndProviderSubject(OAuthProvider.KAKAO, "stable-sub"))
+                .thenReturn(Optional.of(identity));
+
+        service.resolveOrCreate(OAuthProvider.KAKAO, "stable-sub", user.getEmail(), true);
+
+        assertFalse(user.getNicknameSetupRequired());
+        verifyNoInteractions(users, encoder);
+    }
+
+    @Test
+    void newOAuthIdentityReceivesGeneratedNicknameThatMustBeChanged() {
+        UserIdentityRepository identities = mock(UserIdentityRepository.class);
+        UserRepository users = mock(UserRepository.class);
+        PasswordEncoder encoder = mock(PasswordEncoder.class);
+        OAuthIdentityService service = new OAuthIdentityService(identities, users, encoder);
+        when(identities.findByProviderAndProviderSubject(OAuthProvider.KAKAO, "new-subject"))
+                .thenReturn(Optional.empty());
+        when(users.existsByEmail("dayun@example.com")).thenReturn(false);
+        when(users.existsByUsername(anyString())).thenReturn(false);
+        when(encoder.encode(anyString())).thenReturn("encoded-random-password");
+        when(users.save(any(User.class))).thenAnswer(invocation -> {
+            User saved = invocation.getArgument(0);
+            saved.setId(9L);
+            return saved;
+        });
+
+        User user = service.resolveOrCreate(
+                OAuthProvider.KAKAO, "new-subject", "dayun@example.com", true);
+
+        assertEquals("kakao_newsubject", user.getUsername());
+        assertTrue(user.getNicknameSetupRequired());
+        assertFalse(user.getPasswordLoginEnabled());
+        verify(identities).save(any(UserIdentity.class));
     }
 
     @Test

--- a/src/test/java/com/talkwithneighbors/auth/oauth/OAuthNicknameSetupBackfillTest.java
+++ b/src/test/java/com/talkwithneighbors/auth/oauth/OAuthNicknameSetupBackfillTest.java
@@ -1,0 +1,47 @@
+package com.talkwithneighbors.auth.oauth;
+
+import com.talkwithneighbors.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OAuthNicknameSetupBackfillTest {
+    @Test
+    void marksOnlyExactLegacyGeneratedNicknames() throws Exception {
+        UserIdentityRepository identities = mock(UserIdentityRepository.class);
+        User generated = user(7L, "kakao_legacysub");
+        User chosen = user(8L, "다윤이웃");
+        UserIdentity generatedIdentity = UserIdentity.create(
+                OAuthProvider.KAKAO, "legacy-sub", generated, generated.getEmail(), Instant.now());
+        UserIdentity chosenIdentity = UserIdentity.create(
+                OAuthProvider.KAKAO, "chosen-sub", chosen, chosen.getEmail(), Instant.now());
+        ReflectionTestUtils.setField(generatedIdentity, "nicknameSetupAssessed", false);
+        ReflectionTestUtils.setField(chosenIdentity, "nicknameSetupAssessed", false);
+        when(identities.findAll()).thenReturn(List.of(generatedIdentity, chosenIdentity));
+
+        new OAuthNicknameSetupBackfill(identities)
+                .run(new DefaultApplicationArguments(new String[0]));
+
+        assertTrue(generated.getNicknameSetupRequired());
+        assertFalse(chosen.getNicknameSetupRequired());
+        assertTrue(generatedIdentity.isNicknameSetupAssessed());
+        assertTrue(chosenIdentity.isNicknameSetupAssessed());
+    }
+
+    private User user(Long id, String username) {
+        return User.builder()
+                .id(id)
+                .email("user" + id + "@example.com")
+                .username(username)
+                .nicknameSetupRequired(false)
+                .build();
+    }
+}

--- a/src/test/java/com/talkwithneighbors/controller/AuthControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/AuthControllerTest.java
@@ -15,6 +15,7 @@ import com.talkwithneighbors.service.SessionValidationService;
 import com.talkwithneighbors.auth.email.EmailVerificationCookieFactory;
 import com.talkwithneighbors.auth.session.SessionCookieFactory;
 import com.talkwithneighbors.auth.email.EmailVerificationProperties;
+import com.talkwithneighbors.auth.nickname.NicknameException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -279,6 +280,46 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(userDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(userDto.getEmail()));
+    }
+
+    @Test
+    void updateNicknameUsesTheAuthenticatedSession() throws Exception {
+        userDto.setUsername("다윤이웃");
+        userDto.setNicknameSetupRequired(false);
+        when(authService.updateNickname("test-session-id", "다윤이웃")).thenReturn(userDto);
+
+        mockMvc.perform(put("/api/auth/profile/nickname")
+                .cookie(new Cookie("TWN_SESSION", "test-session-id"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"다윤이웃\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("다윤이웃"))
+                .andExpect(jsonPath("$.nicknameSetupRequired").value(false));
+    }
+
+    @Test
+    void shortNicknameReturnsValidationError() throws Exception {
+        mockMvc.perform(put("/api/auth/profile/nickname")
+                .cookie(new Cookie("TWN_SESSION", "test-session-id"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"한\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("validation_failed"))
+                .andExpect(jsonPath("$.fields.nickname").exists());
+    }
+
+    @Test
+    void duplicateNicknameReturnsStableConflictCode() throws Exception {
+        when(authService.updateNickname("test-session-id", "이미사용중"))
+                .thenThrow(new NicknameException(
+                        "USERNAME_ALREADY_IN_USE", "이미 사용 중인 닉네임이에요.", HttpStatus.CONFLICT));
+
+        mockMvc.perform(put("/api/auth/profile/nickname")
+                .cookie(new Cookie("TWN_SESSION", "test-session-id"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nickname\":\"이미사용중\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("USERNAME_ALREADY_IN_USE"));
     }
 
     @Test

--- a/src/test/java/com/talkwithneighbors/service/AuthServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/service/AuthServiceTest.java
@@ -9,6 +9,7 @@ import com.talkwithneighbors.exception.AuthException;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.security.UserSession;
 import com.talkwithneighbors.auth.email.EmailVerificationService;
+import com.talkwithneighbors.auth.nickname.NicknameException;
 import com.talkwithneighbors.auth.session.SessionIssuer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
@@ -190,5 +193,105 @@ class AuthServiceTest {
 
         // when & then
         assertThrows(AuthException.class, () -> authService.getCurrentUser(sessionId));
+    }
+
+    @Test
+    void requiredNicknameCanBeReplacedWithoutResettingTheSession() {
+        testUser.setUsername("kakao_defaultname");
+        testUser.setNicknameSetupRequired(true);
+        UserSession session = UserSession.of(
+                testUser.getId(), testUser.getUsername(), testUser.getEmail(), testUser.getUsername());
+        when(redisSessionService.getSession("test-session-id")).thenReturn(session);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+        when(userRepository.existsByUsernameAndIdNot("다윤이웃", testUser.getId())).thenReturn(false);
+        when(userRepository.saveAndFlush(testUser)).thenReturn(testUser);
+
+        UserDto updated = authService.updateNickname("test-session-id", "  다윤이웃  ");
+
+        assertEquals("다윤이웃", updated.getUsername());
+        assertFalse(updated.isNicknameSetupRequired());
+        verify(redisSessionService).updateSession("test-session-id", testUser.getId(), "다윤이웃");
+    }
+
+    @Test
+    void requiredNicknameCannotConfirmTheGeneratedValueUnchanged() {
+        testUser.setUsername("kakao_defaultname");
+        testUser.setNicknameSetupRequired(true);
+        UserSession session = UserSession.of(
+                testUser.getId(), testUser.getUsername(), testUser.getEmail(), testUser.getUsername());
+        when(redisSessionService.getSession("test-session-id")).thenReturn(session);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+
+        NicknameException exception = assertThrows(NicknameException.class, () ->
+                authService.updateNickname("test-session-id", "kakao_defaultname"));
+
+        assertEquals("NICKNAME_CHANGE_REQUIRED", exception.getCode());
+        verify(userRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void nicknameRejectsWhitespaceAndInvisibleFormatCharacters() {
+        testUser.setNicknameSetupRequired(true);
+        UserSession session = UserSession.of(
+                testUser.getId(), testUser.getUsername(), testUser.getEmail(), testUser.getUsername());
+        when(redisSessionService.getSession("test-session-id")).thenReturn(session);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+
+        NicknameException spaced = assertThrows(NicknameException.class, () ->
+                authService.updateNickname("test-session-id", "다 윤"));
+        NicknameException invisible = assertThrows(NicknameException.class, () ->
+                authService.updateNickname("test-session-id", "다\u200B윤"));
+
+        assertEquals("NICKNAME_INVALID", spaced.getCode());
+        assertEquals("NICKNAME_INVALID", invisible.getCode());
+        verify(userRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void duplicateNicknameReturnsStableConflict() {
+        testUser.setNicknameSetupRequired(true);
+        UserSession session = UserSession.of(
+                testUser.getId(), testUser.getUsername(), testUser.getEmail(), testUser.getUsername());
+        when(redisSessionService.getSession("test-session-id")).thenReturn(session);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+        when(userRepository.existsByUsernameAndIdNot("이미사용중", testUser.getId())).thenReturn(true);
+
+        NicknameException exception = assertThrows(NicknameException.class, () ->
+                authService.updateNickname("test-session-id", "이미사용중"));
+
+        assertEquals("USERNAME_ALREADY_IN_USE", exception.getCode());
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
+    }
+
+    @Test
+    void databaseNicknameRaceAlsoReturnsStableConflict() {
+        testUser.setNicknameSetupRequired(true);
+        UserSession session = UserSession.of(
+                testUser.getId(), testUser.getUsername(), testUser.getEmail(), testUser.getUsername());
+        when(redisSessionService.getSession("test-session-id")).thenReturn(session);
+        when(userRepository.findById(testUser.getId())).thenReturn(Optional.of(testUser));
+        when(userRepository.existsByUsernameAndIdNot("동시요청", testUser.getId())).thenReturn(false);
+        when(userRepository.saveAndFlush(testUser)).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        NicknameException exception = assertThrows(NicknameException.class, () ->
+                authService.updateNickname("test-session-id", "동시요청"));
+
+        assertEquals("USERNAME_ALREADY_IN_USE", exception.getCode());
+    }
+
+    @Test
+    void nicknameSetupKeepsAnOtherwiseCompleteProfileIncomplete() {
+        testUser.setNicknameSetupRequired(true);
+        testUser.setAge(24);
+        testUser.setGender("female");
+        testUser.setInterests(java.util.List.of("산책"));
+        testUser.setLatitude(37.5);
+        testUser.setLongitude(127.0);
+        testUser.setAddress("서울시");
+
+        UserDto dto = UserDto.fromEntity(testUser);
+
+        assertTrue(dto.isNicknameSetupRequired());
+        assertFalse(dto.isProfileComplete());
     }
 }


### PR DESCRIPTION
## What changed

- mark newly created OAuth accounts as requiring an explicit nickname
- backfill legacy provider-generated nicknames once, with a durable assessment marker
- add an authenticated nickname update endpoint with validation, uniqueness handling, and session refresh
- expose `nicknameSetupRequired` and keep profile completion false until setup finishes
- prevent the generic profile endpoint from bypassing the nickname requirement

## Why

Kakao and Google accounts currently receive an internal provider-derived username. That value should never become the public nickname shown on posts, meetups, and chat.

## Impact

Existing OAuth accounts whose nickname still exactly matches the generated format will be prompted once. User-chosen nicknames are preserved, including names that happen to resemble the old generated pattern after assessment.

## Validation

- `gradlew cleanTest test bootJar`
- 0 failures / 0 errors
- focused OAuth, controller, and nickname service tests