### PR TITLE
Add room-scoped chat schedules

### DIFF
--- a/src/main/java/com/talkwithneighbors/controller/ChatScheduleController.java
+++ b/src/main/java/com/talkwithneighbors/controller/ChatScheduleController.java
@@ -1,0 +1,91 @@
+package com.talkwithneighbors.controller;
+
+import com.talkwithneighbors.dto.schedule.CancelChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.ChatScheduleDto;
+import com.talkwithneighbors.dto.schedule.CreateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRsvpRequest;
+import com.talkwithneighbors.security.UserSession;
+import com.talkwithneighbors.service.ChatScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chat/rooms/{roomId}/schedules")
+@RequiredArgsConstructor
+public class ChatScheduleController {
+    private final ChatScheduleService chatScheduleService;
+
+    @PostMapping
+    public ResponseEntity<ChatScheduleDto> create(
+            @PathVariable String roomId,
+            @Valid @RequestBody CreateChatScheduleRequest request,
+            UserSession session
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(chatScheduleService.create(roomId, session.getUserId(), request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChatScheduleDto>> list(
+            @PathVariable String roomId,
+            UserSession session
+    ) {
+        return ResponseEntity.ok(chatScheduleService.list(roomId, session.getUserId()));
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ChatScheduleDto> get(
+            @PathVariable String roomId,
+            @PathVariable String scheduleId,
+            UserSession session
+    ) {
+        return ResponseEntity.ok(chatScheduleService.get(
+                roomId, scheduleId, session.getUserId()));
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<ChatScheduleDto> update(
+            @PathVariable String roomId,
+            @PathVariable String scheduleId,
+            @Valid @RequestBody UpdateChatScheduleRequest request,
+            UserSession session
+    ) {
+        return ResponseEntity.ok(chatScheduleService.update(
+                roomId, scheduleId, session.getUserId(), request));
+    }
+
+    @PostMapping("/{scheduleId}/cancel")
+    public ResponseEntity<ChatScheduleDto> cancel(
+            @PathVariable String roomId,
+            @PathVariable String scheduleId,
+            @Valid @RequestBody CancelChatScheduleRequest request,
+            UserSession session
+    ) {
+        return ResponseEntity.ok(chatScheduleService.cancel(
+                roomId, scheduleId, session.getUserId(), request));
+    }
+
+    @PutMapping("/{scheduleId}/rsvp")
+    public ResponseEntity<ChatScheduleDto> rsvp(
+            @PathVariable String roomId,
+            @PathVariable String scheduleId,
+            @Valid @RequestBody UpdateChatScheduleRsvpRequest request,
+            UserSession session
+    ) {
+        return ResponseEntity.ok(chatScheduleService.rsvp(
+                roomId, scheduleId, session.getUserId(), request));
+    }
+}

--- a/src/main/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEvent.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEvent.java
@@ -1,0 +1,15 @@
+package com.talkwithneighbors.domain.event;
+
+import com.talkwithneighbors.dto.MessageDto;
+
+import java.util.List;
+
+public record ChatScheduleCardChangedEvent(
+        MessageDto message,
+        String roomId,
+        List<Long> participantIds
+) {
+    public ChatScheduleCardChangedEvent {
+        participantIds = participantIds == null ? List.of() : List.copyOf(participantIds);
+    }
+}

--- a/src/main/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEventListener.java
+++ b/src/main/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEventListener.java
@@ -1,0 +1,29 @@
+package com.talkwithneighbors.domain.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatScheduleCardChangedEventListener {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onScheduleCardChanged(ChatScheduleCardChangedEvent event) {
+        try {
+            String destination = "/queue/chat/room/" + event.roomId();
+            event.participantIds().stream()
+                    .distinct()
+                    .forEach(participantId -> messagingTemplate.convertAndSendToUser(
+                            participantId.toString(), destination, event.message()));
+        } catch (Exception exception) {
+            log.error("Failed to dispatch schedule card update. scheduleMessageId={}, roomId={}",
+                    event.message().getId(), event.roomId(), exception);
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/dto/MessageDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/MessageDto.java
@@ -3,6 +3,7 @@ package com.talkwithneighbors.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.talkwithneighbors.entity.Message;
 import com.talkwithneighbors.entity.Message.MessageType;
+import com.talkwithneighbors.dto.schedule.ChatScheduleDto;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -26,6 +27,7 @@ public class MessageDto {
     private String editedAt;
     private String deletedAt;
     private MessageType type;
+    private ChatScheduleDto schedule;
     @JsonProperty("isDeleted")
     private boolean isDeleted;
     private Set<Long> readByUsers;
@@ -54,6 +56,9 @@ public class MessageDto {
             dto.setDeletedAt(message.getDeletedAt().format(formatter));
         }
         dto.setType(message.getType());
+        if (!message.isDeleted() && message.getSchedule() != null) {
+            dto.setSchedule(ChatScheduleDto.fromEntity(message.getSchedule(), currentUserId));
+        }
         dto.setDeleted(message.isDeleted());
         List<com.talkwithneighbors.entity.MessageAttachment> attachments = message.getAttachments();
         if (message.isDeleted()) {

--- a/src/main/java/com/talkwithneighbors/dto/schedule/CancelChatScheduleRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/CancelChatScheduleRequest.java
@@ -1,0 +1,8 @@
+package com.talkwithneighbors.dto.schedule;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CancelChatScheduleRequest(
+        @NotNull(message = "일정 버전이 필요해요.") Long version
+) {
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleDto.java
@@ -1,0 +1,97 @@
+package com.talkwithneighbors.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.talkwithneighbors.entity.ChatSchedule;
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+
+public record ChatScheduleDto(
+        String id,
+        String roomId,
+        Long creatorId,
+        String title,
+        String description,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) OffsetDateTime startsAt,
+        Integer durationMinutes,
+        String timeZone,
+        String location,
+        String locationAddress,
+        Double latitude,
+        Double longitude,
+        String kakaoPlaceId,
+        ChatScheduleStatus status,
+        long version,
+        ChatScheduleRsvpStatus currentUserStatus,
+        ChatScheduleSummaryDto summary,
+        List<ChatScheduleParticipantDto> participants,
+        boolean canEdit,
+        boolean canCancel,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) Instant createdAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) Instant updatedAt,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) Instant cancelledAt
+) {
+    public static ChatScheduleDto fromEntity(ChatSchedule schedule, Long currentUserId) {
+        Long creatorId = schedule.getCreator().getId();
+        List<ChatScheduleRsvp> rsvps = schedule.getRsvps() == null
+                ? List.of()
+                : schedule.getRsvps();
+        List<ChatScheduleParticipantDto> participants = rsvps.stream()
+                .sorted(Comparator
+                        .comparing((ChatScheduleRsvp rsvp) -> !rsvp.getUser().getId().equals(creatorId))
+                        .thenComparing(rsvp -> rsvp.getStatus() != ChatScheduleRsvpStatus.ATTENDING)
+                        .thenComparing(rsvp -> rsvp.getUser().getUsername(), String.CASE_INSENSITIVE_ORDER))
+                .map(rsvp -> new ChatScheduleParticipantDto(
+                        rsvp.getUser().getId(),
+                        rsvp.getUser().getUsername(),
+                        rsvp.getUser().getProfileImage(),
+                        rsvp.getStatus(),
+                        rsvp.getUser().getId().equals(creatorId)))
+                .toList();
+        long attending = participants.stream()
+                .filter(participant -> participant.status() == ChatScheduleRsvpStatus.ATTENDING)
+                .count();
+        long notAttending = participants.size() - attending;
+        ChatScheduleRsvpStatus currentStatus = rsvps.stream()
+                .filter(rsvp -> currentUserId != null && rsvp.getUser().getId().equals(currentUserId))
+                .map(ChatScheduleRsvp::getStatus)
+                .findFirst()
+                .orElse(null);
+        boolean owner = currentUserId != null && creatorId.equals(currentUserId);
+        boolean editable = owner
+                && schedule.getStatus() == ChatScheduleStatus.SCHEDULED
+                && schedule.getStartsAt().isAfter(Instant.now());
+        ZoneId zone = ZoneId.of(schedule.getTimeZone());
+
+        return new ChatScheduleDto(
+                schedule.getId(),
+                schedule.getRoom().getId(),
+                creatorId,
+                schedule.getTitle(),
+                schedule.getDescription(),
+                schedule.getStartsAt().atZone(zone).toOffsetDateTime(),
+                schedule.getDurationMinutes(),
+                schedule.getTimeZone(),
+                schedule.getLocation(),
+                schedule.getLocationAddress(),
+                schedule.getLatitude(),
+                schedule.getLongitude(),
+                schedule.getKakaoPlaceId(),
+                schedule.getStatus(),
+                schedule.getVersion(),
+                currentStatus,
+                new ChatScheduleSummaryDto(attending, notAttending, participants.size()),
+                List.copyOf(participants),
+                editable,
+                editable,
+                schedule.getCreatedAt(),
+                schedule.getUpdatedAt(),
+                schedule.getCancelledAt());
+    }
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleParticipantDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleParticipantDto.java
@@ -1,0 +1,12 @@
+package com.talkwithneighbors.dto.schedule;
+
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+
+public record ChatScheduleParticipantDto(
+        Long userId,
+        String nickname,
+        String profileImage,
+        ChatScheduleRsvpStatus status,
+        boolean host
+) {
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleSummaryDto.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/ChatScheduleSummaryDto.java
@@ -1,0 +1,8 @@
+package com.talkwithneighbors.dto.schedule;
+
+public record ChatScheduleSummaryDto(
+        long attendingCount,
+        long notAttendingCount,
+        long totalResponses
+) {
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/CreateChatScheduleRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/CreateChatScheduleRequest.java
@@ -1,0 +1,62 @@
+package com.talkwithneighbors.dto.schedule;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+public record CreateChatScheduleRequest(
+        @NotBlank(message = "일정 이름을 입력해 주세요.")
+        @Size(max = 80, message = "일정 이름은 80자 이하여야 해요.")
+        String title,
+        @Size(max = 500, message = "일정 설명은 500자 이하여야 해요.")
+        String description,
+        @NotNull(message = "일정 시작 시간을 입력해 주세요.")
+        @Future(message = "일정 시작 시간은 현재 이후여야 해요.")
+        OffsetDateTime startsAt,
+        @NotNull(message = "일정 시간을 입력해 주세요.")
+        @Min(value = 30, message = "일정 시간은 30분 이상이어야 해요.")
+        @Max(value = 1440, message = "일정 시간은 하루를 넘길 수 없어요.")
+        Integer durationMinutes,
+        @NotBlank(message = "시간대를 입력해 주세요.")
+        @Size(max = 64, message = "시간대 값이 너무 길어요.")
+        String timeZone,
+        @Size(max = 100, message = "장소 이름은 100자 이하여야 해요.")
+        String location,
+        @Size(max = 255, message = "장소 주소는 255자 이하여야 해요.")
+        String locationAddress,
+        @DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 해요.")
+        @DecimalMax(value = "90.0", message = "위도는 90 이하여야 해요.")
+        Double latitude,
+        @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 해요.")
+        @DecimalMax(value = "180.0", message = "경도는 180 이하여야 해요.")
+        Double longitude,
+        @Size(max = 64, message = "카카오 장소 ID는 64자 이하여야 해요.")
+        String kakaoPlaceId
+) {
+    @AssertTrue(message = "위도와 경도는 함께 입력해야 해요.")
+    public boolean isCoordinatePairValid() {
+        return (latitude == null) == (longitude == null);
+    }
+
+    @AssertTrue(message = "올바른 IANA 시간대를 입력해 주세요.")
+    public boolean isTimeZoneValid() {
+        if (timeZone == null || timeZone.isBlank()) {
+            return true;
+        }
+        try {
+            ZoneId.of(timeZone);
+            return true;
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/UpdateChatScheduleRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/UpdateChatScheduleRequest.java
@@ -1,0 +1,51 @@
+package com.talkwithneighbors.dto.schedule;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+public record UpdateChatScheduleRequest(
+        @NotNull(message = "일정 버전이 필요해요.") Long version,
+        @Size(max = 80, message = "일정 이름은 80자 이하여야 해요.") String title,
+        @Size(max = 500, message = "일정 설명은 500자 이하여야 해요.") String description,
+        @Future(message = "일정 시작 시간은 현재 이후여야 해요.") OffsetDateTime startsAt,
+        @Min(value = 30, message = "일정 시간은 30분 이상이어야 해요.")
+        @Max(value = 1440, message = "일정 시간은 하루를 넘길 수 없어요.") Integer durationMinutes,
+        @Size(max = 64, message = "시간대 값이 너무 길어요.") String timeZone,
+        @Size(max = 100, message = "장소 이름은 100자 이하여야 해요.") String location,
+        @Size(max = 255, message = "장소 주소는 255자 이하여야 해요.") String locationAddress,
+        @DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 해요.")
+        @DecimalMax(value = "90.0", message = "위도는 90 이하여야 해요.") Double latitude,
+        @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 해요.")
+        @DecimalMax(value = "180.0", message = "경도는 180 이하여야 해요.") Double longitude,
+        @Size(max = 64, message = "카카오 장소 ID는 64자 이하여야 해요.") String kakaoPlaceId
+) {
+    @AssertTrue(message = "위도와 경도는 함께 입력해야 해요.")
+    public boolean isCoordinatePairValid() {
+        if (latitude == null && longitude == null) {
+            return true;
+        }
+        return latitude != null && longitude != null;
+    }
+
+    @AssertTrue(message = "올바른 IANA 시간대를 입력해 주세요.")
+    public boolean isTimeZoneValid() {
+        if (timeZone == null || timeZone.isBlank()) {
+            return true;
+        }
+        try {
+            ZoneId.of(timeZone);
+            return true;
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/talkwithneighbors/dto/schedule/UpdateChatScheduleRsvpRequest.java
+++ b/src/main/java/com/talkwithneighbors/dto/schedule/UpdateChatScheduleRsvpRequest.java
@@ -1,0 +1,9 @@
+package com.talkwithneighbors.dto.schedule;
+
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateChatScheduleRsvpRequest(
+        @NotNull(message = "참석 여부를 선택해 주세요.") ChatScheduleRsvpStatus status
+) {
+}

--- a/src/main/java/com/talkwithneighbors/entity/ChatSchedule.java
+++ b/src/main/java/com/talkwithneighbors/entity/ChatSchedule.java
@@ -1,0 +1,131 @@
+package com.talkwithneighbors.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "chat_schedules",
+        indexes = {
+                @Index(name = "idx_chat_schedule_room_start", columnList = "room_id,status,starts_at"),
+                @Index(name = "idx_chat_schedule_creator", columnList = "creator_id")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatSchedule {
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false)
+    @JsonIgnore
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creator_id", nullable = false)
+    @JsonIgnore
+    private User creator;
+
+    @Column(nullable = false, length = 80)
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "starts_at", nullable = false)
+    private Instant startsAt;
+
+    @Column(name = "duration_minutes", nullable = false)
+    private Integer durationMinutes;
+
+    @Column(name = "time_zone", nullable = false, length = 64)
+    private String timeZone;
+
+    @Column(length = 100)
+    private String location;
+
+    @Column(name = "location_address", length = 255)
+    private String locationAddress;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Column(name = "kakao_place_id", length = 64)
+    private String kakaoPlaceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ChatScheduleStatus status = ChatScheduleStatus.SCHEDULED;
+
+    @Version
+    @Column(nullable = false)
+    private long version;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "cancelled_at")
+    private Instant cancelledAt;
+
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("respondedAt ASC, id ASC")
+    @JsonIgnore
+    private List<ChatScheduleRsvp> rsvps = new ArrayList<>();
+
+    public void addRsvp(ChatScheduleRsvp rsvp) {
+        rsvps.add(rsvp);
+        rsvp.setSchedule(this);
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+        if (status == null) {
+            status = ChatScheduleStatus.SCHEDULED;
+        }
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = createdAt;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/talkwithneighbors/entity/ChatScheduleRsvp.java
+++ b/src/main/java/com/talkwithneighbors/entity/ChatScheduleRsvp.java
@@ -1,0 +1,70 @@
+package com.talkwithneighbors.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "chat_schedule_rsvps",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_chat_schedule_rsvp_schedule_user",
+                columnNames = {"schedule_id", "user_id"}),
+        indexes = @Index(
+                name = "idx_chat_schedule_rsvp_status",
+                columnList = "schedule_id,status,responded_at")
+)
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatScheduleRsvp {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    @JsonIgnore
+    private ChatSchedule schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ChatScheduleRsvpStatus status;
+
+    @Column(name = "responded_at", nullable = false)
+    private Instant respondedAt;
+
+    public ChatScheduleRsvp(ChatSchedule schedule, User user, ChatScheduleRsvpStatus status) {
+        this.schedule = schedule;
+        this.user = user;
+        this.status = status;
+    }
+
+    @PrePersist
+    @PreUpdate
+    void touch() {
+        respondedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/talkwithneighbors/entity/ChatScheduleRsvpStatus.java
+++ b/src/main/java/com/talkwithneighbors/entity/ChatScheduleRsvpStatus.java
@@ -1,0 +1,6 @@
+package com.talkwithneighbors.entity;
+
+public enum ChatScheduleRsvpStatus {
+    ATTENDING,
+    NOT_ATTENDING
+}

--- a/src/main/java/com/talkwithneighbors/entity/ChatScheduleStatus.java
+++ b/src/main/java/com/talkwithneighbors/entity/ChatScheduleStatus.java
@@ -1,0 +1,6 @@
+package com.talkwithneighbors.entity;
+
+public enum ChatScheduleStatus {
+    SCHEDULED,
+    CANCELLED
+}

--- a/src/main/java/com/talkwithneighbors/entity/Message.java
+++ b/src/main/java/com/talkwithneighbors/entity/Message.java
@@ -66,6 +66,14 @@ public class Message {
     @Column(nullable = false)
     private MessageType type;
 
+    /**
+     * Structured schedule card payload. Only SCHEDULE messages reference a row,
+     * and the unique key keeps one stable chat card per schedule.
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", unique = true)
+    private ChatSchedule schedule;
+
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
         name = "message_attachments",
@@ -136,6 +144,7 @@ public class Message {
         IMAGE,      // 이미지
         VIDEO,      // 동영상
         FILE,       // 파일
+        SCHEDULE,   // 채팅방 일정 카드
         SYSTEM      // 시스템 메시지
     }
 }

--- a/src/main/java/com/talkwithneighbors/entity/MessageType.java
+++ b/src/main/java/com/talkwithneighbors/entity/MessageType.java
@@ -5,5 +5,6 @@ public enum MessageType {
     IMAGE,
     VIDEO,
     FILE,
+    SCHEDULE,
     SYSTEM
 }

--- a/src/main/java/com/talkwithneighbors/repository/ChatRoomDeletionRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/ChatRoomDeletionRepository.java
@@ -47,6 +47,12 @@ public class ChatRoomDeletionRepository {
         // Make every pending entity change visible before executing bulk DML.
         entityManager.flush();
 
+        int scheduleRsvps = executeDelete("""
+                DELETE FROM chat_schedule_rsvps
+                WHERE schedule_id IN (
+                    SELECT id FROM chat_schedules WHERE room_id = :roomId
+                )
+                """, roomId);
         int waitlistEntries = executeDelete(
                 "DELETE FROM meetup_waitlist WHERE room_id = :roomId", roomId);
         int readStatuses = executeDelete("""
@@ -63,6 +69,8 @@ public class ChatRoomDeletionRepository {
                 """, roomId);
         int messages = executeDelete(
                 "DELETE FROM messages WHERE chat_room_id = :roomId", roomId);
+        int schedules = executeDelete(
+                "DELETE FROM chat_schedules WHERE room_id = :roomId", roomId);
         int interestTags = executeDelete(
                 "DELETE FROM chat_room_interest_tags WHERE chat_room_id = :roomId", roomId);
         int participants = executeDelete(
@@ -73,6 +81,8 @@ public class ChatRoomDeletionRepository {
         // Native DML bypasses the first-level cache; detach stale room/message entities.
         entityManager.clear();
         return new ChatRoomDeletionResult(
+                scheduleRsvps,
+                schedules,
                 waitlistEntries,
                 readStatuses,
                 attachments,
@@ -99,6 +109,8 @@ public class ChatRoomDeletionRepository {
     }
 
     public record ChatRoomDeletionResult(
+            int scheduleRsvps,
+            int schedules,
             int waitlistEntries,
             int readStatuses,
             int attachments,
@@ -107,5 +119,18 @@ public class ChatRoomDeletionRepository {
             int participants,
             int rooms
     ) {
+        /** Keeps older unit-test fixtures and callers source-compatible. */
+        public ChatRoomDeletionResult(
+                int waitlistEntries,
+                int readStatuses,
+                int attachments,
+                int messages,
+                int interestTags,
+                int participants,
+                int rooms
+        ) {
+            this(0, 0, waitlistEntries, readStatuses, attachments, messages,
+                    interestTags, participants, rooms);
+        }
     }
 }

--- a/src/main/java/com/talkwithneighbors/repository/ChatScheduleRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/ChatScheduleRepository.java
@@ -1,0 +1,54 @@
+package com.talkwithneighbors.repository;
+
+import com.talkwithneighbors.entity.ChatSchedule;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.time.Instant;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+
+public interface ChatScheduleRepository extends JpaRepository<ChatSchedule, String> {
+    boolean existsByRoom_IdAndCreator_IdAndStatusAndStartsAtAfter(
+            String roomId,
+            Long creatorId,
+            ChatScheduleStatus status,
+            Instant startsAt);
+
+    @EntityGraph(attributePaths = {"creator", "rsvps", "rsvps.user"})
+    @Query("""
+            SELECT DISTINCT schedule
+            FROM ChatSchedule schedule
+            WHERE schedule.room.id = :roomId
+            ORDER BY
+              CASE WHEN schedule.status = com.talkwithneighbors.entity.ChatScheduleStatus.SCHEDULED THEN 0 ELSE 1 END,
+              schedule.startsAt ASC,
+              schedule.id ASC
+            """)
+    List<ChatSchedule> findDetailedByRoomId(@Param("roomId") String roomId);
+
+    @EntityGraph(attributePaths = {"creator", "rsvps", "rsvps.user"})
+    @Query("""
+            SELECT schedule
+            FROM ChatSchedule schedule
+            WHERE schedule.id = :scheduleId AND schedule.room.id = :roomId
+            """)
+    Optional<ChatSchedule> findDetailedByIdAndRoomId(
+            @Param("scheduleId") String scheduleId,
+            @Param("roomId") String roomId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT schedule
+            FROM ChatSchedule schedule
+            WHERE schedule.id = :scheduleId AND schedule.room.id = :roomId
+            """)
+    Optional<ChatSchedule> findLockedByIdAndRoomId(
+            @Param("scheduleId") String scheduleId,
+            @Param("roomId") String roomId);
+}

--- a/src/main/java/com/talkwithneighbors/repository/ChatScheduleRsvpRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/ChatScheduleRsvpRepository.java
@@ -1,0 +1,12 @@
+package com.talkwithneighbors.repository;
+
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatScheduleRsvpRepository extends JpaRepository<ChatScheduleRsvp, Long> {
+    Optional<ChatScheduleRsvp> findBySchedule_IdAndUser_Id(String scheduleId, Long userId);
+
+    long deleteBySchedule_Room_IdAndUser_Id(String roomId, Long userId);
+}

--- a/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
+++ b/src/main/java/com/talkwithneighbors/repository/MessageRepository.java
@@ -4,11 +4,13 @@ import com.talkwithneighbors.entity.Message;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 채팅 메시지를 관리하는 리포지토리 인터페이스
@@ -55,4 +57,7 @@ public interface MessageRepository extends JpaRepository<Message, String> {
             @Param("mediaUrl") String mediaUrl,
             @Param("userId") Long userId
     );
+
+    @EntityGraph(attributePaths = {"schedule", "schedule.creator", "schedule.rsvps", "schedule.rsvps.user"})
+    Optional<Message> findBySchedule_IdAndChatRoom_Id(String scheduleId, String roomId);
 }

--- a/src/main/java/com/talkwithneighbors/security/UserSessionArgumentResolver.java
+++ b/src/main/java/com/talkwithneighbors/security/UserSessionArgumentResolver.java
@@ -1,10 +1,12 @@
 package com.talkwithneighbors.security;
 
+import com.talkwithneighbors.exception.AuthException;
 import com.talkwithneighbors.service.SessionValidationService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -42,7 +44,9 @@ public class UserSessionArgumentResolver implements HandlerMethodArgumentResolve
 
         String sessionId = sessionCookie(request);
         if (sessionId == null) {
-            throw new IllegalStateException("An authenticated session is required");
+            throw new AuthException(
+                    "로그인이 필요해.",
+                    HttpStatus.UNAUTHORIZED);
         }
         return sessionValidationService.validateSession(sessionId);
     }

--- a/src/main/java/com/talkwithneighbors/service/ChatScheduleService.java
+++ b/src/main/java/com/talkwithneighbors/service/ChatScheduleService.java
@@ -1,0 +1,398 @@
+package com.talkwithneighbors.service;
+
+import com.talkwithneighbors.domain.event.ChatScheduleCardChangedEvent;
+import com.talkwithneighbors.dto.MessageDto;
+import com.talkwithneighbors.dto.schedule.CancelChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.ChatScheduleDto;
+import com.talkwithneighbors.dto.schedule.CreateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRsvpRequest;
+import com.talkwithneighbors.entity.ChatRoom;
+import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.entity.ChatRoomStatus;
+import com.talkwithneighbors.entity.ChatSchedule;
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+import com.talkwithneighbors.entity.Message;
+import com.talkwithneighbors.entity.User;
+import com.talkwithneighbors.exception.ChatException;
+import com.talkwithneighbors.repository.ChatRoomRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
+import com.talkwithneighbors.repository.MessageRepository;
+import com.talkwithneighbors.repository.UserBlockRepository;
+import com.talkwithneighbors.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatScheduleService {
+    private final ChatScheduleRepository scheduleRepository;
+    private final ChatScheduleRsvpRepository rsvpRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final UserBlockRepository userBlockRepository;
+    private final MessageRepository messageRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public ChatScheduleDto create(
+            String roomId,
+            Long requesterId,
+            CreateChatScheduleRequest request
+    ) {
+        User requester = requireUser(requesterId);
+        ChatRoom room = requireParticipantForUpdate(roomId, requester);
+        requireMutationAllowed(room, requesterId);
+
+        ChatSchedule schedule = new ChatSchedule();
+        schedule.setId(UUID.randomUUID().toString());
+        schedule.setRoom(room);
+        schedule.setCreator(requester);
+        schedule.setTitle(requireTitle(request.title()));
+        schedule.setDescription(trimToNull(request.description()));
+        schedule.setStartsAt(requireFuture(request.startsAt().toInstant()));
+        if (request.durationMinutes() == null) {
+            throw new ChatException("일정 시간을 입력해 줘.", HttpStatus.BAD_REQUEST);
+        }
+        schedule.setDurationMinutes(request.durationMinutes());
+        schedule.setTimeZone(request.timeZone().trim());
+        applyLocation(
+                schedule,
+                request.location(),
+                request.locationAddress(),
+                request.latitude(),
+                request.longitude(),
+                request.kakaoPlaceId());
+        schedule.setStatus(ChatScheduleStatus.SCHEDULED);
+        schedule.addRsvp(new ChatScheduleRsvp(
+                schedule, requester, ChatScheduleRsvpStatus.ATTENDING));
+        scheduleRepository.saveAndFlush(schedule);
+
+        Message card = new Message();
+        card.setId(UUID.randomUUID().toString());
+        card.setChatRoom(room);
+        card.setSender(requester);
+        card.setContent(cardPreview(schedule));
+        card.setType(Message.MessageType.SCHEDULE);
+        card.setSchedule(schedule);
+        card.setCreatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        card.getReadByUsers().add(requesterId);
+        messageRepository.saveAndFlush(card);
+
+        room.setLastMessage(card.getContent());
+        room.setLastMessageTime(card.getCreatedAt());
+        chatRoomRepository.save(room);
+
+        publishCard(room, card);
+        return ChatScheduleDto.fromEntity(schedule, requesterId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatScheduleDto> list(String roomId, Long requesterId) {
+        User requester = requireUser(requesterId);
+        requireParticipant(roomId, requester);
+        return scheduleRepository.findDetailedByRoomId(roomId).stream()
+                .map(schedule -> ChatScheduleDto.fromEntity(schedule, requesterId))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ChatScheduleDto get(String roomId, String scheduleId, Long requesterId) {
+        User requester = requireUser(requesterId);
+        requireParticipant(roomId, requester);
+        return ChatScheduleDto.fromEntity(
+                requireDetailedSchedule(roomId, scheduleId), requesterId);
+    }
+
+    public ChatScheduleDto update(
+            String roomId,
+            String scheduleId,
+            Long requesterId,
+            UpdateChatScheduleRequest request
+    ) {
+        User requester = requireUser(requesterId);
+        ChatRoom room = requireParticipant(roomId, requester);
+        requireMutationAllowed(room, requesterId);
+        ChatSchedule schedule = requireDetailedSchedule(roomId, scheduleId);
+        requireCreator(schedule, requesterId);
+        requireScheduled(schedule);
+        requireNotStarted(schedule);
+        requireVersion(schedule, request.version());
+
+        if (request.title() != null) {
+            schedule.setTitle(requireTitle(request.title()));
+        }
+        if (request.description() != null) {
+            schedule.setDescription(trimToNull(request.description()));
+        }
+        if (request.startsAt() != null) {
+            schedule.setStartsAt(requireFuture(request.startsAt().toInstant()));
+        }
+        if (request.durationMinutes() != null) {
+            schedule.setDurationMinutes(request.durationMinutes());
+        }
+        if (request.timeZone() != null) {
+            if (request.timeZone().isBlank()) {
+                throw new ChatException("시간대를 비워둘 수 없어요.", HttpStatus.BAD_REQUEST);
+            }
+            schedule.setTimeZone(request.timeZone().trim());
+        }
+        // The editor submits the complete location group. An all-null group means
+        // that the member intentionally removed the place from this schedule.
+        applyLocation(
+                schedule,
+                request.location(),
+                request.locationAddress(),
+                request.latitude(),
+                request.longitude(),
+                request.kakaoPlaceId());
+
+        flushWithConflict(schedule);
+        Message card = requireCard(roomId, scheduleId);
+        card.setContent(cardPreview(schedule));
+        card.setUpdatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        messageRepository.save(card);
+        refreshRoomPreviewWhenCardIsLatest(room, card);
+        publishCard(room, card);
+        return ChatScheduleDto.fromEntity(schedule, requesterId);
+    }
+
+    public ChatScheduleDto cancel(
+            String roomId,
+            String scheduleId,
+            Long requesterId,
+            CancelChatScheduleRequest request
+    ) {
+        User requester = requireUser(requesterId);
+        ChatRoom room = requireParticipant(roomId, requester);
+        requireMutationAllowed(room, requesterId);
+        ChatSchedule schedule = requireDetailedSchedule(roomId, scheduleId);
+        requireCreator(schedule, requesterId);
+        if (schedule.getStatus() == ChatScheduleStatus.CANCELLED) {
+            return ChatScheduleDto.fromEntity(schedule, requesterId);
+        }
+        requireNotStarted(schedule);
+        requireVersion(schedule, request.version());
+
+        schedule.setStatus(ChatScheduleStatus.CANCELLED);
+        schedule.setCancelledAt(Instant.now());
+        flushWithConflict(schedule);
+        Message card = requireCard(roomId, scheduleId);
+        card.setContent(cardPreview(schedule));
+        card.setUpdatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        messageRepository.save(card);
+        refreshRoomPreviewWhenCardIsLatest(room, card);
+        publishCard(room, card);
+        return ChatScheduleDto.fromEntity(schedule, requesterId);
+    }
+
+    public ChatScheduleDto rsvp(
+            String roomId,
+            String scheduleId,
+            Long requesterId,
+            UpdateChatScheduleRsvpRequest request
+    ) {
+        User requester = requireUser(requesterId);
+        ChatRoom room = requireParticipant(roomId, requester);
+        requireMutationAllowed(room, requesterId);
+        ChatSchedule schedule = scheduleRepository.findLockedByIdAndRoomId(scheduleId, roomId)
+                .orElseThrow(this::scheduleNotFound);
+        requireScheduled(schedule);
+        requireNotStarted(schedule);
+
+        if (schedule.getCreator().getId().equals(requesterId)
+                && request.status() == ChatScheduleRsvpStatus.NOT_ATTENDING) {
+            throw new ChatException(
+                    "일정을 만든 사람은 불참으로 변경할 수 없어. 먼저 일정을 취소해 줘.",
+                    HttpStatus.CONFLICT);
+        }
+
+        var existingRsvp = rsvpRepository
+                .findBySchedule_IdAndUser_Id(scheduleId, requesterId);
+        if (existingRsvp.isPresent() && existingRsvp.get().getStatus() == request.status()) {
+            return ChatScheduleDto.fromEntity(schedule, requesterId);
+        }
+        ChatScheduleRsvp rsvp = existingRsvp
+                .orElseGet(() -> {
+                    ChatScheduleRsvp created = new ChatScheduleRsvp(
+                            schedule, requester, request.status());
+                    schedule.addRsvp(created);
+                    return created;
+                });
+        rsvp.setStatus(request.status());
+        rsvpRepository.saveAndFlush(rsvp);
+        // RSVP changes are also schedule-card revisions. Bumping the optimistic
+        // version gives clients a monotonic ordering key for realtime upserts.
+        schedule.setUpdatedAt(Instant.now());
+        flushWithConflict(schedule);
+
+        Message card = requireCard(roomId, scheduleId);
+        publishCard(room, card);
+        return ChatScheduleDto.fromEntity(schedule, requesterId);
+    }
+
+    private User requireUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ChatException("사용자를 찾을 수 없어.", HttpStatus.NOT_FOUND));
+    }
+
+    private ChatRoom requireParticipant(String roomId, User user) {
+        return chatRoomRepository.findByIdAndParticipantsContaining(roomId, user)
+                .orElseThrow(() -> new ChatException(
+                        "채팅방을 찾을 수 없거나 참가자가 아니야.", HttpStatus.NOT_FOUND));
+    }
+
+    private ChatRoom requireParticipantForUpdate(String roomId, User user) {
+        ChatRoom room = chatRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new ChatException("채팅방을 찾을 수 없어.", HttpStatus.NOT_FOUND));
+        boolean participant = room.getParticipants().stream()
+                .anyMatch(candidate -> candidate.getId().equals(user.getId()));
+        if (!participant) {
+            throw new ChatException(
+                    "채팅방을 찾을 수 없거나 참가자가 아니야.", HttpStatus.NOT_FOUND);
+        }
+        return room;
+    }
+
+    private ChatSchedule requireDetailedSchedule(String roomId, String scheduleId) {
+        return scheduleRepository.findDetailedByIdAndRoomId(scheduleId, roomId)
+                .orElseThrow(this::scheduleNotFound);
+    }
+
+    private ChatException scheduleNotFound() {
+        return new ChatException("일정을 찾을 수 없어.", HttpStatus.NOT_FOUND);
+    }
+
+    private void requireCreator(ChatSchedule schedule, Long requesterId) {
+        if (!schedule.getCreator().getId().equals(requesterId)) {
+            throw new ChatException("일정을 만든 사람만 변경하거나 취소할 수 있어.", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    private void requireScheduled(ChatSchedule schedule) {
+        if (schedule.getStatus() != ChatScheduleStatus.SCHEDULED) {
+            throw new ChatException("취소된 일정은 변경할 수 없어.", HttpStatus.CONFLICT);
+        }
+    }
+
+    private void requireNotStarted(ChatSchedule schedule) {
+        if (schedule.getStartsAt() == null || !schedule.getStartsAt().isAfter(Instant.now())) {
+            throw new ChatException("이미 시작한 일정은 변경할 수 없어.", HttpStatus.CONFLICT);
+        }
+    }
+
+    private void requireVersion(ChatSchedule schedule, Long expectedVersion) {
+        if (expectedVersion == null || schedule.getVersion() != expectedVersion) {
+            throw new ChatException(
+                    "다른 사용자가 일정을 먼저 변경했어. 새로고침 후 다시 시도해 줘.",
+                    HttpStatus.CONFLICT);
+        }
+    }
+
+    private void requireMutationAllowed(ChatRoom room, Long requesterId) {
+        if (room.getStatus() == ChatRoomStatus.CLOSED) {
+            throw new ChatException("닫힌 채팅방의 일정은 변경할 수 없어.", HttpStatus.CONFLICT);
+        }
+        if (room.getType() != ChatRoomType.ONE_ON_ONE) {
+            return;
+        }
+        room.getParticipants().stream()
+                .filter(participant -> !participant.getId().equals(requesterId))
+                .findFirst()
+                .ifPresent(participant -> {
+                    if (userBlockRepository.existsBetween(requesterId, participant.getId())) {
+                        throw new ChatException(
+                                "차단 관계인 사용자와는 1:1 채팅 일정을 변경할 수 없어.",
+                                HttpStatus.FORBIDDEN);
+                    }
+                });
+    }
+
+    private Message requireCard(String roomId, String scheduleId) {
+        return messageRepository.findBySchedule_IdAndChatRoom_Id(scheduleId, roomId)
+                .orElseThrow(() -> new ChatException("일정 카드를 찾을 수 없어.", HttpStatus.NOT_FOUND));
+    }
+
+    private void publishCard(ChatRoom room, Message card) {
+        // This payload is shared by every room member. currentUserStatus must stay
+        // null here; clients derive their own state from the participant list.
+        MessageDto sharedMessage = MessageDto.fromEntity(card, null);
+        applicationEventPublisher.publishEvent(new ChatScheduleCardChangedEvent(
+                sharedMessage,
+                room.getId(),
+                room.getParticipants().stream().map(User::getId).toList()));
+    }
+
+    private void refreshRoomPreviewWhenCardIsLatest(ChatRoom room, Message card) {
+        if (card.getCreatedAt() != null && card.getCreatedAt().equals(room.getLastMessageTime())) {
+            room.setLastMessage(card.getContent());
+            chatRoomRepository.save(room);
+        }
+    }
+
+    private void flushWithConflict(ChatSchedule schedule) {
+        try {
+            scheduleRepository.saveAndFlush(schedule);
+        } catch (OptimisticLockingFailureException exception) {
+            throw new ChatException(
+                    "다른 사용자가 일정을 먼저 변경했어. 새로고침 후 다시 시도해 줘.",
+                    HttpStatus.CONFLICT);
+        }
+    }
+
+    private String requireTitle(String value) {
+        String title = value == null ? "" : value.trim();
+        if (title.isEmpty()) {
+            throw new ChatException("일정 이름을 입력해 줘.", HttpStatus.BAD_REQUEST);
+        }
+        return title;
+    }
+
+    private Instant requireFuture(Instant startsAt) {
+        if (startsAt == null || !startsAt.isAfter(Instant.now())) {
+            throw new ChatException("일정 시작 시간은 현재 이후여야 해.", HttpStatus.BAD_REQUEST);
+        }
+        return startsAt;
+    }
+
+    private void applyLocation(
+            ChatSchedule schedule,
+            String location,
+            String locationAddress,
+            Double latitude,
+            Double longitude,
+            String kakaoPlaceId
+    ) {
+        if ((latitude == null) != (longitude == null)) {
+            throw new ChatException("위도와 경도는 함께 입력해야 해.", HttpStatus.BAD_REQUEST);
+        }
+        schedule.setLocation(trimToNull(location));
+        schedule.setLocationAddress(trimToNull(locationAddress));
+        schedule.setLatitude(latitude);
+        schedule.setLongitude(longitude);
+        schedule.setKakaoPlaceId(trimToNull(kakaoPlaceId));
+    }
+
+    private String cardPreview(ChatSchedule schedule) {
+        return schedule.getStatus() == ChatScheduleStatus.CANCELLED
+                ? "취소된 일정: " + schedule.getTitle()
+                : "일정: " + schedule.getTitle();
+    }
+
+    private String trimToNull(String value) {
+        return value == null || value.trim().isEmpty() ? null : value.trim();
+    }
+}

--- a/src/main/java/com/talkwithneighbors/service/HobbyMeetupService.java
+++ b/src/main/java/com/talkwithneighbors/service/HobbyMeetupService.java
@@ -13,7 +13,10 @@ import com.talkwithneighbors.repository.ChatRoomRepository;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.repository.UserBlockRepository;
 import com.talkwithneighbors.repository.MeetupWaitlistRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
 import com.talkwithneighbors.entity.MeetupWaitlistEntry;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
 import com.talkwithneighbors.outbox.DomainEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -47,6 +50,8 @@ public class HobbyMeetupService {
     private final DomainEventPublisher domainEventPublisher;
     private final UserBlockRepository userBlockRepository;
     private final MeetupWaitlistRepository meetupWaitlistRepository;
+    private final ChatScheduleRepository chatScheduleRepository;
+    private final ChatScheduleRsvpRepository chatScheduleRsvpRepository;
     private final OfflineNotificationService offlineNotificationService;
     private final ObjectMapper objectMapper;
 
@@ -161,6 +166,12 @@ public class HobbyMeetupService {
     public void leaveMeetup(Long userId, String roomId) {
         User user = getUser(userId);
         ChatRoom room = getPublicMeetup(roomId);
+        if (chatScheduleRepository.existsByRoom_IdAndCreator_IdAndStatusAndStartsAtAfter(
+                roomId, userId, ChatScheduleStatus.SCHEDULED, Instant.now())) {
+            throw new ChatException(
+                    "먼저 이 채팅방에서 만든 예정 일정을 취소해 줘.",
+                    HttpStatus.CONFLICT);
+        }
         if (meetupWaitlistRepository.existsByRoom_IdAndUser_Id(roomId, userId)) {
             meetupWaitlistRepository.deleteByRoom_IdAndUser_Id(roomId, userId);
             return;
@@ -168,6 +179,7 @@ public class HobbyMeetupService {
         if (!room.getParticipants().remove(user)) {
             throw new ChatException("You are not a participant in this hobby meetup.", HttpStatus.BAD_REQUEST);
         }
+        chatScheduleRsvpRepository.deleteBySchedule_Room_IdAndUser_Id(roomId, userId);
         meetupWaitlistRepository.findFirstByRoom_IdOrderByCreatedAtAsc(roomId).ifPresent(entry -> {
             room.getParticipants().add(entry.getUser());
             meetupWaitlistRepository.delete(entry);

--- a/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/talkwithneighbors/service/impl/ChatServiceImpl.java
@@ -18,6 +18,9 @@ import com.talkwithneighbors.entity.User;
 import com.talkwithneighbors.exception.ChatException;
 import com.talkwithneighbors.repository.ChatRoomRepository;
 import com.talkwithneighbors.repository.ChatRoomDeletionRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
 import com.talkwithneighbors.repository.MessageRepository;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.repository.UserBlockRepository;
@@ -56,6 +59,8 @@ public class ChatServiceImpl implements ChatService {
     private final UserBlockRepository userBlockRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final ChatRoomDeletionRepository chatRoomDeletionRepository;
+    private final ChatScheduleRepository chatScheduleRepository;
+    private final ChatScheduleRsvpRepository chatScheduleRsvpRepository;
     private final DomainEventPublisher domainEventPublisher;
 
     @Override
@@ -200,7 +205,14 @@ public class ChatServiceImpl implements ChatService {
                 .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new RuntimeException("Chat room not found"));
+        if (chatScheduleRepository.existsByRoom_IdAndCreator_IdAndStatusAndStartsAtAfter(
+                roomId, userId, ChatScheduleStatus.SCHEDULED, java.time.Instant.now())) {
+            throw new ChatException(
+                    "먼저 이 채팅방에서 만든 예정 일정을 취소해 줘.",
+                    HttpStatus.CONFLICT);
+        }
         if (chatRoom.getParticipants().remove(user)) {
+            chatScheduleRsvpRepository.deleteBySchedule_Room_IdAndUser_Id(roomId, userId);
             chatRoomRepository.save(chatRoom);
             log.info("User {} left room {}", user.getId(), roomId);
         } else {
@@ -592,14 +604,17 @@ public class ChatServiceImpl implements ChatService {
                     ChatRoomDeletedEvent.create(roomId, participantIds));
 
             log.info(
-                    "[deleteRoom] Deleted room graph. roomId={}, messages={}, attachments={}, "
-                            + "readStatuses={}, participants={}, waitlistEntries={}",
+                "[deleteRoom] Deleted room graph. roomId={}, messages={}, attachments={}, "
+                            + "readStatuses={}, participants={}, waitlistEntries={}, "
+                            + "schedules={}, scheduleRsvps={}",
                     roomId,
                     result.messages(),
                     result.attachments(),
                     result.readStatuses(),
                     result.participants(),
-                    result.waitlistEntries()
+                    result.waitlistEntries(),
+                    result.schedules(),
+                    result.scheduleRsvps()
             );
         } catch (ChatException exception) {
             throw exception;

--- a/src/test/java/com/talkwithneighbors/controller/ChatScheduleControllerTest.java
+++ b/src/test/java/com/talkwithneighbors/controller/ChatScheduleControllerTest.java
@@ -1,0 +1,208 @@
+package com.talkwithneighbors.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.talkwithneighbors.config.TestSecurityConfig;
+import com.talkwithneighbors.dto.schedule.ChatScheduleDto;
+import com.talkwithneighbors.dto.schedule.ChatScheduleParticipantDto;
+import com.talkwithneighbors.dto.schedule.ChatScheduleSummaryDto;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+import com.talkwithneighbors.security.UserSession;
+import com.talkwithneighbors.service.ChatScheduleService;
+import com.talkwithneighbors.service.SessionValidationService;
+import com.talkwithneighbors.repository.MessageRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ChatScheduleController.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({TestSecurityConfig.class, ChatExceptionHandler.class})
+class ChatScheduleControllerTest {
+    private static final String SESSION_ID = "schedule-session";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean ChatScheduleService chatScheduleService;
+    @MockBean SessionValidationService sessionValidationService;
+    @MockBean org.springframework.session.SessionRepository<?> sessionRepository;
+    @MockBean MessageRepository messageRepository;
+
+    @BeforeEach
+    void setUp() {
+        when(sessionValidationService.validateSession(SESSION_ID))
+                .thenReturn(UserSession.of(1L, "host", "host@example.test", "host"));
+    }
+
+    @Test
+    void createUsesRoomScopedEndpointAndReturnsRawSchedule() throws Exception {
+        when(chatScheduleService.create(eq("room-1"), eq(1L), any()))
+                .thenReturn(schedule());
+
+        mockMvc.perform(post("/api/chat/rooms/{roomId}/schedules", "room-1")
+                        .cookie(sessionCookie())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"저녁 산책",
+                                  "description":"같이 걸어요",
+                                  "startsAt":"2099-07-18T19:00:00+09:00",
+                                  "durationMinutes":90,
+                                  "timeZone":"Asia/Seoul",
+                                  "location":"서울숲",
+                                  "locationAddress":"서울 성동구 뚝섬로 273",
+                                  "latitude":37.5444,
+                                  "longitude":127.0374,
+                                  "kakaoPlaceId":"place-1"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("schedule-1"))
+                .andExpect(jsonPath("$.title").value("저녁 산책"))
+                .andExpect(jsonPath("$.participants[0].nickname").value("host"))
+                .andExpect(jsonPath("$.participants[0].profileImage").value("/profiles/host.webp"))
+                .andExpect(jsonPath("$.participants[0].email").doesNotExist())
+                .andExpect(jsonPath("$.participants[0].address").doesNotExist());
+    }
+
+    @Test
+    void createRejectsMissingDurationBeforeService() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms/{roomId}/schedules", "room-1")
+                        .cookie(sessionCookie())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"저녁 산책",
+                                  "startsAt":"2099-07-18T19:00:00+09:00",
+                                  "timeZone":"Asia/Seoul"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void listReturnsAnArrayRatherThanPageEnvelope() throws Exception {
+        when(chatScheduleService.list("room-1", 1L)).thenReturn(List.of(schedule()));
+
+        mockMvc.perform(get("/api/chat/rooms/{roomId}/schedules", "room-1")
+                        .cookie(sessionCookie()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("schedule-1"));
+    }
+
+    @Test
+    void listWithoutSessionReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/chat/rooms/{roomId}/schedules", "room-1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createWithoutSessionReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/chat/rooms/{roomId}/schedules", "room-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"Evening walk",
+                                  "startsAt":"2099-07-18T19:00:00+09:00",
+                                  "durationMinutes":90,
+                                  "timeZone":"Asia/Seoul"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void updateCancelAndRsvpReturnRawSchedule() throws Exception {
+        when(chatScheduleService.update(eq("room-1"), eq("schedule-1"), eq(1L), any()))
+                .thenReturn(schedule());
+        when(chatScheduleService.cancel(eq("room-1"), eq("schedule-1"), eq(1L), any()))
+                .thenReturn(schedule());
+        when(chatScheduleService.rsvp(eq("room-1"), eq("schedule-1"), eq(1L), any()))
+                .thenReturn(schedule());
+
+        mockMvc.perform(patch("/api/chat/rooms/{roomId}/schedules/{scheduleId}",
+                        "room-1", "schedule-1")
+                        .cookie(sessionCookie())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"version\":0,\"title\":\"변경\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("schedule-1"));
+
+        mockMvc.perform(post("/api/chat/rooms/{roomId}/schedules/{scheduleId}/cancel",
+                        "room-1", "schedule-1")
+                        .cookie(sessionCookie())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"version\":0}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("schedule-1"));
+
+        mockMvc.perform(put("/api/chat/rooms/{roomId}/schedules/{scheduleId}/rsvp",
+                        "room-1", "schedule-1")
+                        .cookie(sessionCookie())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"NOT_ATTENDING\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("schedule-1"));
+    }
+
+    private Cookie sessionCookie() {
+        return new Cookie("TWN_SESSION", SESSION_ID);
+    }
+
+    private ChatScheduleDto schedule() {
+        Instant now = Instant.parse("2099-07-01T00:00:00Z");
+        return new ChatScheduleDto(
+                "schedule-1",
+                "room-1",
+                1L,
+                "저녁 산책",
+                "같이 걸어요",
+                OffsetDateTime.parse("2099-07-18T19:00:00+09:00"),
+                90,
+                "Asia/Seoul",
+                "서울숲",
+                "서울 성동구 뚝섬로 273",
+                37.5444,
+                127.0374,
+                "place-1",
+                ChatScheduleStatus.SCHEDULED,
+                0L,
+                ChatScheduleRsvpStatus.ATTENDING,
+                new ChatScheduleSummaryDto(1, 0, 1),
+                List.of(new ChatScheduleParticipantDto(
+                        1L,
+                        "host",
+                        "/profiles/host.webp",
+                        ChatScheduleRsvpStatus.ATTENDING,
+                        true)),
+                true,
+                true,
+                now,
+                now,
+                null);
+    }
+}

--- a/src/test/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEventListenerTest.java
+++ b/src/test/java/com/talkwithneighbors/domain/event/ChatScheduleCardChangedEventListenerTest.java
@@ -1,0 +1,42 @@
+package com.talkwithneighbors.domain.event;
+
+import com.talkwithneighbors.dto.MessageDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class ChatScheduleCardChangedEventListenerTest {
+    @Test
+    void sendsStableCardToEveryDistinctRoomParticipantAfterCommit() throws Exception {
+        SimpMessagingTemplate messagingTemplate = mock(SimpMessagingTemplate.class);
+        ChatScheduleCardChangedEventListener listener =
+                new ChatScheduleCardChangedEventListener(messagingTemplate);
+        MessageDto message = new MessageDto();
+        message.setId("schedule-card-1");
+
+        listener.onScheduleCardChanged(new ChatScheduleCardChangedEvent(
+                message, "room-1", List.of(1L, 2L, 1L)));
+
+        verify(messagingTemplate).convertAndSendToUser(
+                "1", "/queue/chat/room/room-1", message);
+        verify(messagingTemplate).convertAndSendToUser(
+                "2", "/queue/chat/room/room-1", message);
+        verifyNoMoreInteractions(messagingTemplate);
+
+        Method method = ChatScheduleCardChangedEventListener.class
+                .getMethod("onScheduleCardChanged", ChatScheduleCardChangedEvent.class);
+        TransactionalEventListener annotation =
+                method.getAnnotation(TransactionalEventListener.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+}

--- a/src/test/java/com/talkwithneighbors/dto/schedule/ChatScheduleRequestValidationTest.java
+++ b/src/test/java/com/talkwithneighbors/dto/schedule/ChatScheduleRequestValidationTest.java
@@ -1,0 +1,68 @@
+package com.talkwithneighbors.dto.schedule;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatScheduleRequestValidationTest {
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void requiresDurationAndAnIanaTimeZone() {
+        CreateChatScheduleRequest request = new CreateChatScheduleRequest(
+                "산책",
+                null,
+                OffsetDateTime.now().plusDays(1),
+                null,
+                "Seoul",
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("durationMinutes", "timeZoneValid");
+    }
+
+    @Test
+    void coordinatesMustBeACompleteWgs84Pair() {
+        CreateChatScheduleRequest request = new CreateChatScheduleRequest(
+                "산책",
+                null,
+                OffsetDateTime.now().plusDays(1),
+                60,
+                "Asia/Seoul",
+                "서울숲",
+                null,
+                37.5,
+                null,
+                null);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("coordinatePairValid");
+    }
+
+    @Test
+    void acceptsOffsetTimestampAndKakaoLocation() {
+        CreateChatScheduleRequest request = new CreateChatScheduleRequest(
+                "산책",
+                "같이 걸어요",
+                OffsetDateTime.now().plusDays(1),
+                60,
+                "Asia/Seoul",
+                "서울숲",
+                "서울 성동구 뚝섬로 273",
+                37.5444,
+                127.0374,
+                "place-1");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
@@ -3,6 +3,10 @@ package com.talkwithneighbors.repository;
 import com.talkwithneighbors.entity.ChatAttachmentType;
 import com.talkwithneighbors.entity.ChatRoom;
 import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.entity.ChatSchedule;
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
 import com.talkwithneighbors.entity.MeetupWaitlistEntry;
 import com.talkwithneighbors.entity.Message;
 import com.talkwithneighbors.entity.MessageAttachment;
@@ -29,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +65,12 @@ class ChatRoomDeletionMySqlIntegrationTest {
 
     @Autowired
     private MeetupWaitlistRepository meetupWaitlistRepository;
+
+    @Autowired
+    private ChatScheduleRepository chatScheduleRepository;
+
+    @Autowired
+    private ChatScheduleRsvpRepository chatScheduleRsvpRepository;
 
     @Autowired
     private EntityManager entityManager;
@@ -147,6 +158,30 @@ class ChatRoomDeletionMySqlIntegrationTest {
 
             if (includeWaitlist) {
                 meetupWaitlistRepository.saveAndFlush(new MeetupWaitlistEntry(room, peer));
+
+                ChatSchedule schedule = new ChatSchedule();
+                schedule.setId("schedule-" + suffix);
+                schedule.setRoom(room);
+                schedule.setCreator(owner);
+                schedule.setTitle("Deletion-linked schedule");
+                schedule.setStartsAt(Instant.now().plusSeconds(86_400));
+                schedule.setDurationMinutes(90);
+                schedule.setTimeZone("Asia/Seoul");
+                schedule.setStatus(ChatScheduleStatus.SCHEDULED);
+                schedule = chatScheduleRepository.saveAndFlush(schedule);
+
+                chatScheduleRsvpRepository.saveAndFlush(new ChatScheduleRsvp(
+                        schedule, peer, ChatScheduleRsvpStatus.ATTENDING));
+
+                Message scheduleCard = new Message();
+                scheduleCard.setId("schedule-message-" + suffix);
+                scheduleCard.setChatRoom(room);
+                scheduleCard.setSender(owner);
+                scheduleCard.setContent("일정: Deletion-linked schedule");
+                scheduleCard.setType(Message.MessageType.SCHEDULE);
+                scheduleCard.setSchedule(schedule);
+                scheduleCard.setReadByUsers(new HashSet<>(List.of(owner.getId())));
+                messageRepository.saveAndFlush(scheduleCard);
             }
 
             entityManager.flush();
@@ -177,6 +212,11 @@ class ChatRoomDeletionMySqlIntegrationTest {
         assertCount(0, "SELECT COUNT(*) FROM chat_room_participants WHERE chat_room_id = ?", fixture.roomId());
         assertCount(0, "SELECT COUNT(*) FROM chat_room_interest_tags WHERE chat_room_id = ?", fixture.roomId());
         assertCount(0, "SELECT COUNT(*) FROM meetup_waitlist WHERE room_id = ?", fixture.roomId());
+        assertCount(0, "SELECT COUNT(*) FROM chat_schedules WHERE room_id = ?", fixture.roomId());
+        assertCount(0, """
+                SELECT COUNT(*) FROM chat_schedule_rsvps
+                WHERE schedule_id IN (SELECT id FROM chat_schedules WHERE room_id = ?)
+                """, fixture.roomId());
         assertCount(1, "SELECT COUNT(*) FROM users WHERE id = ?", fixture.ownerId());
         assertCount(1, "SELECT COUNT(*) FROM users WHERE id = ?", fixture.peerId());
     }

--- a/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatRoomDeletionMySqlIntegrationTest.java
@@ -160,7 +160,7 @@ class ChatRoomDeletionMySqlIntegrationTest {
                 meetupWaitlistRepository.saveAndFlush(new MeetupWaitlistEntry(room, peer));
 
                 ChatSchedule schedule = new ChatSchedule();
-                schedule.setId("schedule-" + suffix);
+                schedule.setId(UUID.randomUUID().toString());
                 schedule.setRoom(room);
                 schedule.setCreator(owner);
                 schedule.setTitle("Deletion-linked schedule");

--- a/src/test/java/com/talkwithneighbors/repository/ChatSchedulePersistenceTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatSchedulePersistenceTest.java
@@ -1,0 +1,113 @@
+package com.talkwithneighbors.repository;
+
+import com.talkwithneighbors.entity.ChatRoom;
+import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.entity.ChatSchedule;
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+import com.talkwithneighbors.entity.Message;
+import com.talkwithneighbors.entity.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import com.talkwithneighbors.config.TestConfig;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({ChatRoomDeletionRepository.class, TestConfig.class})
+class ChatSchedulePersistenceTest {
+    @Autowired UserRepository userRepository;
+    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired ChatScheduleRepository chatScheduleRepository;
+    @Autowired ChatScheduleRsvpRepository chatScheduleRsvpRepository;
+    @Autowired MessageRepository messageRepository;
+    @Autowired ChatRoomDeletionRepository deletionRepository;
+    @Autowired EntityManager entityManager;
+
+    @Test
+    void oneRoomStoresMultipleDetailedSchedulesAndDeletionRemovesTheirGraph() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+        User host = userRepository.save(user("host-" + suffix));
+        User member = userRepository.save(user("member-" + suffix));
+        ChatRoom room = new ChatRoom();
+        room.setId("room-" + suffix);
+        room.setName("schedule persistence");
+        room.setType(ChatRoomType.GROUP);
+        room.setCreator(host);
+        room.setParticipants(new HashSet<>(List.of(host, member)));
+        room = chatRoomRepository.saveAndFlush(room);
+
+        ChatSchedule morning = saveSchedule(room, host, "morning-" + suffix, "아침 산책", 1);
+        ChatSchedule evening = saveSchedule(room, member, "evening-" + suffix, "저녁 식사", 2);
+        chatScheduleRsvpRepository.saveAndFlush(new ChatScheduleRsvp(
+                morning, member, ChatScheduleRsvpStatus.ATTENDING));
+
+        Message card = new Message();
+        card.setId("card-" + suffix);
+        card.setChatRoom(room);
+        card.setSender(host);
+        card.setContent("일정: 아침 산책");
+        card.setType(Message.MessageType.SCHEDULE);
+        card.setSchedule(morning);
+        messageRepository.saveAndFlush(card);
+        entityManager.clear();
+
+        List<ChatSchedule> schedules = chatScheduleRepository.findDetailedByRoomId(room.getId());
+        assertThat(schedules).extracting(ChatSchedule::getId)
+                .containsExactly(morning.getId(), evening.getId());
+        assertThat(schedules.get(0).getRsvps()).hasSize(2);
+        assertThat(messageRepository.findBySchedule_IdAndChatRoom_Id(morning.getId(), room.getId()))
+                .get().extracting(Message::getId).isEqualTo(card.getId());
+
+        ChatRoomDeletionRepository.ChatRoomDeletionResult result =
+                deletionRepository.deleteByRoomId(room.getId());
+
+        assertThat(result.scheduleRsvps()).isEqualTo(3);
+        assertThat(result.schedules()).isEqualTo(2);
+        assertThat(chatRoomRepository.findById(room.getId())).isEmpty();
+        assertThat(chatScheduleRepository.count()).isZero();
+        assertThat(chatScheduleRsvpRepository.count()).isZero();
+        assertThat(messageRepository.findById(card.getId())).isEmpty();
+    }
+
+    private ChatSchedule saveSchedule(
+            ChatRoom room,
+            User creator,
+            String id,
+            String title,
+            int daysFromNow
+    ) {
+        ChatSchedule schedule = new ChatSchedule();
+        schedule.setId(id);
+        schedule.setRoom(room);
+        schedule.setCreator(creator);
+        schedule.setTitle(title);
+        schedule.setStartsAt(Instant.now().plusSeconds(daysFromNow * 86_400L));
+        schedule.setDurationMinutes(90);
+        schedule.setTimeZone("Asia/Seoul");
+        schedule.setStatus(ChatScheduleStatus.SCHEDULED);
+        schedule.addRsvp(new ChatScheduleRsvp(
+                schedule, creator, ChatScheduleRsvpStatus.ATTENDING));
+        return chatScheduleRepository.saveAndFlush(schedule);
+    }
+
+    private User user(String username) {
+        return User.builder()
+                .email(username + "@example.invalid")
+                .username(username)
+                .password("hash")
+                .latitude(37.5)
+                .longitude(127.0)
+                .address("Seoul")
+                .build();
+    }
+}

--- a/src/test/java/com/talkwithneighbors/service/ChatScheduleServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/service/ChatScheduleServiceTest.java
@@ -1,0 +1,459 @@
+package com.talkwithneighbors.service;
+
+import com.talkwithneighbors.domain.event.ChatScheduleCardChangedEvent;
+import com.talkwithneighbors.dto.schedule.CancelChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.CreateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRequest;
+import com.talkwithneighbors.dto.schedule.UpdateChatScheduleRsvpRequest;
+import com.talkwithneighbors.entity.ChatRoom;
+import com.talkwithneighbors.entity.ChatRoomType;
+import com.talkwithneighbors.entity.ChatRoomStatus;
+import com.talkwithneighbors.entity.ChatSchedule;
+import com.talkwithneighbors.entity.ChatScheduleRsvp;
+import com.talkwithneighbors.entity.ChatScheduleRsvpStatus;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
+import com.talkwithneighbors.entity.Message;
+import com.talkwithneighbors.entity.User;
+import com.talkwithneighbors.exception.ChatException;
+import com.talkwithneighbors.repository.ChatRoomRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
+import com.talkwithneighbors.repository.MessageRepository;
+import com.talkwithneighbors.repository.UserBlockRepository;
+import com.talkwithneighbors.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatScheduleServiceTest {
+    @Mock ChatScheduleRepository scheduleRepository;
+    @Mock ChatScheduleRsvpRepository rsvpRepository;
+    @Mock ChatRoomRepository chatRoomRepository;
+    @Mock UserRepository userRepository;
+    @Mock UserBlockRepository userBlockRepository;
+    @Mock MessageRepository messageRepository;
+    @Mock ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks ChatScheduleService service;
+
+    private User host;
+    private User member;
+    private ChatRoom room;
+
+    @BeforeEach
+    void setUp() {
+        host = user(1L, "host", "/profiles/host.webp");
+        member = user(2L, "member", "/profiles/member.webp");
+        room = new ChatRoom();
+        room.setId("room-1");
+        room.setName("동네 채팅");
+        room.setType(ChatRoomType.GROUP);
+        room.setCreator(host);
+        room.setParticipants(new HashSet<>(List.of(host, member)));
+    }
+
+    @Test
+    void participantCreatesScheduleWithHostAttendingAndStableCard() {
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdForUpdate(room.getId())).thenReturn(Optional.of(room));
+        when(scheduleRepository.saveAndFlush(any(ChatSchedule.class)))
+                .thenAnswer(invocation -> initialize(invocation.getArgument(0)));
+        when(messageRepository.saveAndFlush(any(Message.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = service.create(room.getId(), host.getId(), createRequest("저녁 산책"));
+
+        assertThat(result.title()).isEqualTo("저녁 산책");
+        assertThat(result.currentUserStatus()).isEqualTo(ChatScheduleRsvpStatus.ATTENDING);
+        assertThat(result.participants()).singleElement().satisfies(participant -> {
+            assertThat(participant.userId()).isEqualTo(host.getId());
+            assertThat(participant.nickname()).isEqualTo("host");
+            assertThat(participant.profileImage()).isEqualTo("/profiles/host.webp");
+            assertThat(participant.host()).isTrue();
+            assertThat(participant.status()).isEqualTo(ChatScheduleRsvpStatus.ATTENDING);
+        });
+
+        ArgumentCaptor<Message> card = ArgumentCaptor.forClass(Message.class);
+        verify(messageRepository).saveAndFlush(card.capture());
+        assertThat(card.getValue().getType()).isEqualTo(Message.MessageType.SCHEDULE);
+        assertThat(card.getValue().getSchedule().getId()).isEqualTo(result.id());
+        assertThat(room.getLastMessage()).isEqualTo("일정: 저녁 산책");
+
+        ArgumentCaptor<ChatScheduleCardChangedEvent> event =
+                ArgumentCaptor.forClass(ChatScheduleCardChangedEvent.class);
+        verify(applicationEventPublisher).publishEvent(event.capture());
+        assertThat(event.getValue().participantIds()).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(event.getValue().message().getSchedule().currentUserStatus()).isNull();
+    }
+
+    @Test
+    void outsiderCannotCreateOrLearnWhetherRoomExists() {
+        User outsider = user(9L, "outsider", null);
+        when(userRepository.findById(outsider.getId())).thenReturn(Optional.of(outsider));
+        when(chatRoomRepository.findByIdForUpdate(room.getId())).thenReturn(Optional.of(room));
+
+        assertThatThrownBy(() -> service.create(
+                room.getId(), outsider.getId(), createRequest("몰래 만든 일정")))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+
+        verify(scheduleRepository, never()).save(any());
+        verify(messageRepository, never()).save(any());
+    }
+
+    @Test
+    void closedRoomRejectsScheduleMutationsButCanStillBeRead() {
+        room.setStatus(ChatRoomStatus.CLOSED);
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdForUpdate(room.getId())).thenReturn(Optional.of(room));
+
+        assertThatThrownBy(() -> service.create(
+                room.getId(), host.getId(), createRequest("닫힌 방 일정")))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+        verify(scheduleRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void roomCanContainMultipleSchedules() {
+        ChatSchedule first = schedule("schedule-1", host, "아침 산책");
+        ChatSchedule second = schedule("schedule-2", member, "저녁 식사");
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), member))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByRoomId(room.getId()))
+                .thenReturn(List.of(first, second));
+
+        var schedules = service.list(room.getId(), member.getId());
+
+        assertThat(schedules).extracting(result -> result.id())
+                .containsExactly("schedule-1", "schedule-2");
+    }
+
+    @Test
+    void onlyScheduleCreatorCanUpdate() {
+        ChatSchedule schedule = schedule("schedule-1", host, "기존 일정");
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), member))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        assertThatThrownBy(() -> service.update(
+                room.getId(), schedule.getId(), member.getId(), updateRequest(0L, "변경")))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.FORBIDDEN));
+
+        verify(scheduleRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void creatorUpdatesScheduleAndRebroadcastsSameCardId() {
+        ChatSchedule schedule = schedule("schedule-1", host, "기존 일정");
+        schedule.setVersion(3L);
+        Message card = card("message-1", schedule);
+        room.setLastMessage(card.getContent());
+        room.setLastMessageTime(card.getCreatedAt());
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+        when(scheduleRepository.saveAndFlush(schedule)).thenAnswer(invocation -> {
+            schedule.setVersion(4L);
+            return schedule;
+        });
+        when(messageRepository.findBySchedule_IdAndChatRoom_Id(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(card));
+
+        var result = service.update(
+                room.getId(), schedule.getId(), host.getId(), updateRequest(3L, "변경된 일정"));
+
+        assertThat(result.title()).isEqualTo("변경된 일정");
+        assertThat(result.version()).isEqualTo(4L);
+        ArgumentCaptor<ChatScheduleCardChangedEvent> event =
+                ArgumentCaptor.forClass(ChatScheduleCardChangedEvent.class);
+        verify(applicationEventPublisher).publishEvent(event.capture());
+        assertThat(event.getValue().message().getId()).isEqualTo("message-1");
+        assertThat(event.getValue().message().getSchedule().currentUserStatus()).isNull();
+        assertThat(room.getLastMessage()).isEqualTo("일정: 변경된 일정");
+    }
+
+    @Test
+    void staleVersionIsRejected() {
+        ChatSchedule schedule = schedule("schedule-1", host, "기존 일정");
+        schedule.setVersion(5L);
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        assertThatThrownBy(() -> service.update(
+                room.getId(), schedule.getId(), host.getId(), updateRequest(4L, "충돌")))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+        verify(scheduleRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void creatorCancelsInsteadOfDeletingSchedule() {
+        ChatSchedule schedule = schedule("schedule-1", host, "취소할 일정");
+        Message card = card("message-1", schedule);
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+        when(scheduleRepository.saveAndFlush(schedule)).thenReturn(schedule);
+        when(messageRepository.findBySchedule_IdAndChatRoom_Id(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(card));
+
+        var result = service.cancel(
+                room.getId(), schedule.getId(), host.getId(), new CancelChatScheduleRequest(0L));
+
+        assertThat(result.status()).isEqualTo(ChatScheduleStatus.CANCELLED);
+        assertThat(result.cancelledAt()).isNotNull();
+        assertThat(card.getContent()).isEqualTo("취소된 일정: 취소할 일정");
+        verify(scheduleRepository, never()).delete(any());
+    }
+
+    @Test
+    void participantRsvpIsAnIdempotentUpsertAndRebroadcastsCard() {
+        ChatSchedule schedule = schedule("schedule-1", host, "참석 조사");
+        Message card = card("message-1", schedule);
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), member))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findLockedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+        when(rsvpRepository.findBySchedule_IdAndUser_Id(schedule.getId(), member.getId()))
+                .thenReturn(Optional.empty());
+        when(rsvpRepository.saveAndFlush(any(ChatScheduleRsvp.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(messageRepository.findBySchedule_IdAndChatRoom_Id(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(card));
+
+        var result = service.rsvp(
+                room.getId(), schedule.getId(), member.getId(),
+                new UpdateChatScheduleRsvpRequest(ChatScheduleRsvpStatus.NOT_ATTENDING));
+
+        assertThat(result.currentUserStatus()).isEqualTo(ChatScheduleRsvpStatus.NOT_ATTENDING);
+        assertThat(result.participants()).extracting(participant -> participant.nickname())
+                .contains("host", "member");
+        ArgumentCaptor<ChatScheduleRsvp> response = ArgumentCaptor.forClass(ChatScheduleRsvp.class);
+        verify(rsvpRepository).saveAndFlush(response.capture());
+        assertThat(response.getValue().getStatus()).isEqualTo(ChatScheduleRsvpStatus.NOT_ATTENDING);
+        verify(scheduleRepository).saveAndFlush(schedule);
+        verify(applicationEventPublisher).publishEvent(any(ChatScheduleCardChangedEvent.class));
+    }
+
+    @Test
+    void unchangedRsvpIsANoOpWithoutVersionOrWebSocketChurn() {
+        ChatSchedule schedule = schedule("schedule-1", host, "참석 조사");
+        ChatScheduleRsvp memberRsvp = new ChatScheduleRsvp(
+                schedule, member, ChatScheduleRsvpStatus.ATTENDING);
+        schedule.addRsvp(memberRsvp);
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), member))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findLockedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+        when(rsvpRepository.findBySchedule_IdAndUser_Id(schedule.getId(), member.getId()))
+                .thenReturn(Optional.of(memberRsvp));
+
+        var result = service.rsvp(
+                room.getId(), schedule.getId(), member.getId(),
+                new UpdateChatScheduleRsvpRequest(ChatScheduleRsvpStatus.ATTENDING));
+
+        assertThat(result.currentUserStatus()).isEqualTo(ChatScheduleRsvpStatus.ATTENDING);
+        verify(rsvpRepository, never()).saveAndFlush(any());
+        verify(scheduleRepository, never()).saveAndFlush(any());
+        verify(messageRepository, never()).findBySchedule_IdAndChatRoom_Id(any(), any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void hostCannotRsvpNotAttending() {
+        ChatSchedule schedule = schedule("schedule-1", host, "참석 조사");
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findLockedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        assertThatThrownBy(() -> service.rsvp(
+                room.getId(), schedule.getId(), host.getId(),
+                new UpdateChatScheduleRsvpRequest(ChatScheduleRsvpStatus.NOT_ATTENDING)))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+        verify(rsvpRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void startedScheduleCannotBeUpdated() {
+        ChatSchedule schedule = schedule("schedule-1", host, "이미 시작");
+        schedule.setStartsAt(Instant.now().minusSeconds(1));
+        assertThat(com.talkwithneighbors.dto.schedule.ChatScheduleDto
+                .fromEntity(schedule, host.getId()).canEdit()).isFalse();
+        assertThat(com.talkwithneighbors.dto.schedule.ChatScheduleDto
+                .fromEntity(schedule, host.getId()).canCancel()).isFalse();
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        assertThatThrownBy(() -> service.update(
+                room.getId(), schedule.getId(), host.getId(), updateRequest(0L, "늦은 변경")))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT));
+    }
+
+    @Test
+    void fullFormUpdateCanClearAnExistingLocation() {
+        ChatSchedule schedule = schedule("schedule-1", host, "장소 제거");
+        schedule.setLocation("서울숲");
+        schedule.setLocationAddress("서울 성동구");
+        schedule.setLatitude(37.5);
+        schedule.setLongitude(127.0);
+        schedule.setKakaoPlaceId("place-1");
+        Message card = card("message-1", schedule);
+        when(userRepository.findById(host.getId())).thenReturn(Optional.of(host));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), host))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findDetailedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+        when(scheduleRepository.saveAndFlush(schedule)).thenReturn(schedule);
+        when(messageRepository.findBySchedule_IdAndChatRoom_Id(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(card));
+
+        service.update(room.getId(), schedule.getId(), host.getId(), updateRequest(0L, "장소 제거"));
+
+        assertThat(schedule.getLocation()).isNull();
+        assertThat(schedule.getLocationAddress()).isNull();
+        assertThat(schedule.getLatitude()).isNull();
+        assertThat(schedule.getLongitude()).isNull();
+        assertThat(schedule.getKakaoPlaceId()).isNull();
+    }
+
+    @Test
+    void cancelledScheduleRejectsRsvp() {
+        ChatSchedule schedule = schedule("schedule-1", host, "취소됨");
+        schedule.setStatus(ChatScheduleStatus.CANCELLED);
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findByIdAndParticipantsContaining(room.getId(), member))
+                .thenReturn(Optional.of(room));
+        when(scheduleRepository.findLockedByIdAndRoomId(schedule.getId(), room.getId()))
+                .thenReturn(Optional.of(schedule));
+
+        assertThatThrownBy(() -> service.rsvp(
+                room.getId(), schedule.getId(), member.getId(),
+                new UpdateChatScheduleRsvpRequest(ChatScheduleRsvpStatus.ATTENDING)))
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+        verify(rsvpRepository, never()).saveAndFlush(any());
+    }
+
+    private CreateChatScheduleRequest createRequest(String title) {
+        return new CreateChatScheduleRequest(
+                title,
+                "같이 걸어요",
+                OffsetDateTime.now().plusDays(2),
+                90,
+                "Asia/Seoul",
+                "서울숲",
+                "서울 성동구 뚝섬로 273",
+                37.5444,
+                127.0374,
+                "kakao-place-1");
+    }
+
+    private UpdateChatScheduleRequest updateRequest(Long version, String title) {
+        return new UpdateChatScheduleRequest(
+                version,
+                title,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private ChatSchedule schedule(String id, User creator, String title) {
+        ChatSchedule schedule = new ChatSchedule();
+        schedule.setId(id);
+        schedule.setRoom(room);
+        schedule.setCreator(creator);
+        schedule.setTitle(title);
+        schedule.setStartsAt(Instant.now().plusSeconds(86_400));
+        schedule.setDurationMinutes(120);
+        schedule.setTimeZone("Asia/Seoul");
+        schedule.setStatus(ChatScheduleStatus.SCHEDULED);
+        schedule.setCreatedAt(Instant.now());
+        schedule.setUpdatedAt(Instant.now());
+        schedule.addRsvp(new ChatScheduleRsvp(
+                schedule, creator, ChatScheduleRsvpStatus.ATTENDING));
+        return schedule;
+    }
+
+    private Message card(String id, ChatSchedule schedule) {
+        Message message = new Message();
+        message.setId(id);
+        message.setChatRoom(room);
+        message.setSender(schedule.getCreator());
+        message.setType(Message.MessageType.SCHEDULE);
+        message.setContent("일정: " + schedule.getTitle());
+        message.setSchedule(schedule);
+        message.setCreatedAt(LocalDateTime.now());
+        return message;
+    }
+
+    private ChatSchedule initialize(ChatSchedule schedule) {
+        if (schedule.getCreatedAt() == null) {
+            schedule.setCreatedAt(Instant.now());
+        }
+        if (schedule.getUpdatedAt() == null) {
+            schedule.setUpdatedAt(schedule.getCreatedAt());
+        }
+        return schedule;
+    }
+
+    private User user(Long id, String username, String profileImage) {
+        User user = new User();
+        user.setId(id);
+        user.setUsername(username);
+        user.setProfileImage(profileImage);
+        return user;
+    }
+}

--- a/src/test/java/com/talkwithneighbors/service/HobbyMeetupServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/service/HobbyMeetupServiceTest.java
@@ -12,6 +12,9 @@ import com.talkwithneighbors.repository.ChatRoomRepository;
 import com.talkwithneighbors.repository.UserRepository;
 import com.talkwithneighbors.repository.UserBlockRepository;
 import com.talkwithneighbors.repository.MeetupWaitlistRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.talkwithneighbors.outbox.DomainEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +31,7 @@ import java.util.Optional;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,6 +57,12 @@ class HobbyMeetupServiceTest {
 
     @Mock
     private MeetupWaitlistRepository meetupWaitlistRepository;
+
+    @Mock
+    private ChatScheduleRepository chatScheduleRepository;
+
+    @Mock
+    private ChatScheduleRsvpRepository chatScheduleRsvpRepository;
 
     @Mock
     private OfflineNotificationService offlineNotificationService;
@@ -165,7 +175,36 @@ class HobbyMeetupServiceTest {
 
         assertFalse(room.getParticipants().contains(member));
         assertTrue(room.getParticipants().contains(creator));
+        verify(chatScheduleRsvpRepository)
+                .deleteBySchedule_Room_IdAndUser_Id(room.getId(), member.getId());
         verify(chatRoomRepository).save(room);
+    }
+
+    @Test
+    void creatorMustCancelFutureChatScheduleBeforeLeavingMeetup() {
+        User member = user(2L, "member", "카페");
+        ChatRoom room = publicMeetup("meetup-with-schedule", 5);
+        room.getParticipants().add(creator);
+        room.getParticipants().add(member);
+
+        when(userRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(chatRoomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+        when(chatScheduleRepository.existsByRoom_IdAndCreator_IdAndStatusAndStartsAtAfter(
+                org.mockito.ArgumentMatchers.eq(room.getId()),
+                org.mockito.ArgumentMatchers.eq(member.getId()),
+                org.mockito.ArgumentMatchers.eq(ChatScheduleStatus.SCHEDULED),
+                org.mockito.ArgumentMatchers.any(Instant.class)))
+                .thenReturn(true);
+
+        ChatException exception = assertThrows(
+                ChatException.class,
+                () -> hobbyMeetupService.leaveMeetup(member.getId(), room.getId()));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
+        assertTrue(room.getParticipants().contains(member));
+        verify(chatScheduleRsvpRepository, never())
+                .deleteBySchedule_Room_IdAndUser_Id(any(), any());
+        verify(chatRoomRepository, never()).save(room);
     }
 
     private ChatRoom publicMeetup(String id, int maxParticipants) {

--- a/src/test/java/com/talkwithneighbors/service/impl/ChatServiceImplTest.java
+++ b/src/test/java/com/talkwithneighbors/service/impl/ChatServiceImplTest.java
@@ -13,6 +13,9 @@ import com.talkwithneighbors.repository.ChatRoomDeletionRepository;
 import com.talkwithneighbors.repository.ChatRoomRepository;
 import com.talkwithneighbors.repository.MessageRepository;
 import com.talkwithneighbors.repository.UserRepository;
+import com.talkwithneighbors.repository.ChatScheduleRepository;
+import com.talkwithneighbors.repository.ChatScheduleRsvpRepository;
+import com.talkwithneighbors.entity.ChatScheduleStatus;
 import com.talkwithneighbors.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -63,6 +67,12 @@ class ChatServiceImplTest {
 
     @Mock
     private NotificationService notificationService;
+
+    @Mock
+    private ChatScheduleRepository chatScheduleRepository;
+
+    @Mock
+    private ChatScheduleRsvpRepository chatScheduleRsvpRepository;
 
     @InjectMocks
     private ChatServiceImpl chatService;
@@ -376,6 +386,41 @@ class ChatServiceImplTest {
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
         verifyNoInteractions(applicationEventPublisher, domainEventPublisher);
+    }
+
+    @Test
+    void leavingRoomRemovesScheduleRsvps() {
+        when(userRepository.findById(participant.getId())).thenReturn(Optional.of(participant));
+        when(chatRoomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+
+        chatService.leaveRoom(room.getId(), participant.getId().toString());
+
+        assertFalse(room.getParticipants().contains(participant));
+        verify(chatScheduleRsvpRepository)
+                .deleteBySchedule_Room_IdAndUser_Id(room.getId(), participant.getId());
+        verify(chatRoomRepository).save(room);
+    }
+
+    @Test
+    void scheduleCreatorCannotLeaveBeforeCancellingFutureSchedule() {
+        when(userRepository.findById(participant.getId())).thenReturn(Optional.of(participant));
+        when(chatRoomRepository.findById(room.getId())).thenReturn(Optional.of(room));
+        when(chatScheduleRepository.existsByRoom_IdAndCreator_IdAndStatusAndStartsAtAfter(
+                eq(room.getId()),
+                eq(participant.getId()),
+                eq(ChatScheduleStatus.SCHEDULED),
+                any(Instant.class)))
+                .thenReturn(true);
+
+        ChatException exception = assertThrows(
+                ChatException.class,
+                () -> chatService.leaveRoom(room.getId(), participant.getId().toString()));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatus());
+        assertTrue(room.getParticipants().contains(participant));
+        verify(chatScheduleRsvpRepository, never())
+                .deleteBySchedule_Room_IdAndUser_Id(anyString(), any());
+        verify(chatRoomRepository, never()).save(room);
     }
 
     @Test


### PR DESCRIPTION
## What changed

- Added multiple room-scoped chat schedules with Kakao place fields, UTC time storage, RSVP status, participant-safe DTOs, optimistic versioning, and soft cancellation.
- Added a stable `SCHEDULE` chat message card that is re-broadcast to every room participant after commit when the schedule or attendance changes.
- Enforced room participation, creator-only editing/cancellation, creator attendance, started/closed schedule guards, and anonymous 401 behavior.
- Cleaned schedule RSVPs on leave, blocked hosts from leaving with an upcoming schedule, and extended room graph deletion for schedule data.

## Why

The existing hobby meetup model stores one date and place on the chat room itself. That cannot represent multiple appointments inside one ongoing meetup chat. This adds a separate schedule lifecycle while preserving the existing public meetup feature.

## Impact

Participants can create and manage several appointments in one meetup room and see a privacy-minimized participant list. Existing meetup and ordinary chat APIs remain compatible.

## Validation

- `./gradlew cleanTest test`
- 260 tests passed, 0 failed, 0 skipped
- H2 persistence and MySQL room-deletion integration coverage
- Controller 401/validation contracts and after-commit WebSocket fan-out tests
- `git diff --check`