### PR TITLE
Fix MySQL 8.4 restore verification

### DIFF
--- a/deploy/k8s/mysql-backup-restore-verify.sh
+++ b/deploy/k8s/mysql-backup-restore-verify.sh
@@ -109,10 +109,21 @@ restored_table_count="$(mysql_root_query "SELECT COUNT(*) FROM information_schem
 [[ "$restored_table_count" == "$expected_table_count" ]] || { echo "Restore verification table count does not match the manifest" >&2; exit 1; }
 migration_table_count="$(mysql_root_query "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '${scratch_schema}' AND table_name = 'app_schema_migrations'")"
 [[ "$migration_table_count" == "1" ]] || { echo "Restore verification is missing app_schema_migrations" >&2; exit 1; }
+table_check_statements="$(mysql_root_query "SELECT CONCAT('CHECK TABLE \`${scratch_schema}\`.\`', REPLACE(table_name, '\`', '\`\`'), '\`;') FROM information_schema.tables WHERE table_schema = '${scratch_schema}' ORDER BY table_name")"
+[[ -n "$table_check_statements" ]] || { echo "Restore verification found no tables to check" >&2; exit 1; }
+# MySQL 8.4 images no longer ship mysqlcheck. Run the equivalent CHECK TABLE
+# statements through the mysql client that is already required for restore.
 # shellcheck disable=SC2016
-k3s kubectl -n "$NAMESPACE" exec statefulset/mysql -- sh -ec \
-  'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" exec mysqlcheck --user=root --check "$1"' \
-  sh "$scratch_schema" >/dev/null
+table_check_output="$(
+  printf '%s\n' "$table_check_statements" |
+    timeout 1800 k3s kubectl -n "$NAMESPACE" exec -i statefulset/mysql -- sh -ec \
+      'MYSQL_PWD="$MYSQL_ROOT_PASSWORD" exec mysql --user=root --batch --skip-column-names --raw'
+)"
+printf '%s\n' "$table_check_output" | awk -F '\t' -v expected="$expected_table_count" '
+  NF < 4 || $3 != "status" || $4 != "OK" { exit 1 }
+  { checked += 1 }
+  END { if (checked != expected) exit 1 }
+' || { echo "Restore verification table check failed" >&2; exit 1; }
 mysql_root_query "DROP DATABASE \`${scratch_schema}\`" >/dev/null
 scratch_schema=""
 

--- a/deploy/k8s/tests/mysql-backup-contract.sh
+++ b/deploy/k8s/tests/mysql-backup-contract.sh
@@ -42,7 +42,13 @@ manifest_upload_line="$(grep -nF -m1 'aws s3 cp "$manifest_path"' "$BACKUP" | cu
 
 grep -Fq 'DROP DATABASE IF EXISTS' "$RESTORE"
 grep -Fq 'app_schema_migrations' "$RESTORE"
-grep -Fq 'mysqlcheck --user=root --check' "$RESTORE"
+grep -Fq 'CHECK TABLE' "$RESTORE"
+grep -Fq 'exec mysql --user=root --batch --skip-column-names --raw' "$RESTORE"
+grep -Fq 'checked != expected' "$RESTORE"
+if grep -Fq 'mysqlcheck' < <(grep -v '^#' "$RESTORE"); then
+  echo "Restore verification must work with the MySQL 8.4 image, which does not ship mysqlcheck" >&2
+  exit 1
+fi
 grep -Fq 'mysql/daily/' "$RESTORE"
 grep -Fq 'MYSQL_BACKUP_BUCKET' "$BUILD_BUNDLE"
 grep -Fq 'install-mysql-backup.sh' "$BUILD_BUNDLE"


### PR DESCRIPTION
## Summary
- replace the removed `mysqlcheck` dependency with MySQL 8.4-compatible `CHECK TABLE` statements executed through the existing `mysql` client
- validate that every restored table produces an exact `status / OK` result
- require the number of successful table checks to match the committed backup manifest
- guard the MySQL 8.4 contract so `mysqlcheck` cannot be reintroduced

## Production evidence
- encrypted backup creation and S3 manifest verification succeeded
- the previous isolated restore failed with exit 127 because the pinned MySQL 8.4 image does not contain `mysqlcheck`
- the cleanup trap removed the scratch schema; production data was not changed

## Validation
- Bash syntax checks for both changed scripts
- `deploy/k8s/tests/mysql-backup-contract.sh`
- ShellCheck v0.11.0 for both changed scripts
- `git diff --check`