### PR TITLE
Fix production collation in calendar backfill

### DIFF
--- a/deploy/k8s/database-migrations/V2026071601__backfill_chat_schedule_calendar.sql
+++ b/deploy/k8s/database-migrations/V2026071601__backfill_chat_schedule_calendar.sql
@@ -180,14 +180,16 @@ JOIN chat_rooms room
   ON room.id = pending.room_id
 SET message.sender_id = room.creator_id,
     message.content = CONCAT(
-        CONVERT(0xEC9DBCECA0953A20 USING utf8mb4), LEFT(room.name, 80)),
+        CONVERT(0xEC9DBCECA0953A20 USING utf8mb4), LEFT(room.name, 80)
+    ) COLLATE utf8mb4_unicode_ci,
     message.updated_at = UTC_TIMESTAMP(6)
 WHERE message.chat_room_id = room.id
   AND message.type = 'SCHEDULE'
   AND NOT (
     message.sender_id <=> room.creator_id
     AND message.content <=> CONCAT(
-        CONVERT(0xEC9DBCECA0953A20 USING utf8mb4), LEFT(room.name, 80))
+        CONVERT(0xEC9DBCECA0953A20 USING utf8mb4), LEFT(room.name, 80)
+    ) COLLATE utf8mb4_unicode_ci
   );
 
 -- Join by schedule_id rather than the generated ID: an earlier application

--- a/src/test/java/com/talkwithneighbors/repository/ChatScheduleCalendarMigrationMySqlIntegrationTest.java
+++ b/src/test/java/com/talkwithneighbors/repository/ChatScheduleCalendarMigrationMySqlIntegrationTest.java
@@ -70,6 +70,8 @@ class ChatScheduleCalendarMigrationMySqlIntegrationTest {
 
     @Test
     void backfillRepairsDependentsForPreexistingDeterministicScheduleAndIsRetrySafe() {
+        useProductionMessageContentCollation();
+
         String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         User host = userRepository.saveAndFlush(user("calendar-migration-" + suffix));
 
@@ -87,6 +89,17 @@ class ChatScheduleCalendarMigrationMySqlIntegrationTest {
         stalePartialSchedule.setTitle("stale partial title");
         stalePartialSchedule.setDurationMinutes(30);
         chatScheduleRepository.saveAndFlush(stalePartialSchedule);
+        String partialMessageId = deterministicId(
+                "legacy-chat-schedule-message:", partialScheduleId);
+        Message stalePartialCard = new Message();
+        stalePartialCard.setId(partialMessageId);
+        stalePartialCard.setChatRoom(partialRoom);
+        stalePartialCard.setSender(host);
+        stalePartialCard.setContent("Stale schedule card");
+        stalePartialCard.setCreatedAt(LocalDateTime.now(ZoneOffset.UTC));
+        stalePartialCard.setType(Message.MessageType.SCHEDULE);
+        stalePartialCard.setSchedule(stalePartialSchedule);
+        messageRepository.saveAndFlush(stalePartialCard);
 
         Instant representedStart = Instant.parse("2099-08-03T10:00:00Z");
         ChatRoom representedRoom = chatRoomRepository.saveAndFlush(
@@ -128,7 +141,10 @@ class ChatScheduleCalendarMigrationMySqlIntegrationTest {
         assertCompleteBackfill(cleanRoom.getId(), cleanScheduleId,
                 deterministicId("legacy-chat-schedule-message:", cleanScheduleId), host.getId());
         assertCompleteBackfill(partialRoom.getId(), partialScheduleId,
-                deterministicId("legacy-chat-schedule-message:", partialScheduleId), host.getId());
+                partialMessageId, host.getId());
+        assertThat(messageRepository.findById(partialMessageId)).get().satisfies(message ->
+                assertThat(message.getContent()).isEqualTo(
+                        "일정: Calendar migration meetup"));
         assertThat(chatScheduleRepository.findById(partialScheduleId)).get().satisfies(schedule -> {
             assertThat(schedule.getStartsAt()).isEqualTo(partialStart.minusSeconds(86_400));
             assertThat(schedule.getTitle()).isEqualTo("stale partial title");
@@ -230,6 +246,22 @@ class ChatScheduleCalendarMigrationMySqlIntegrationTest {
                 Integer.class,
                 messageId,
                 userId);
+    }
+
+    private void useProductionMessageContentCollation() {
+        jdbcTemplate.execute("""
+                ALTER TABLE messages
+                MODIFY COLUMN content TEXT
+                CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+                """);
+        assertThat(jdbcTemplate.queryForObject("""
+                        SELECT COLLATION_NAME
+                        FROM INFORMATION_SCHEMA.COLUMNS
+                        WHERE TABLE_SCHEMA = DATABASE()
+                          AND TABLE_NAME = 'messages'
+                          AND COLUMN_NAME = 'content'
+                        """, String.class))
+                .isEqualTo("utf8mb4_unicode_ci");
     }
 
     private void applyMigration() {


### PR DESCRIPTION
## Production incident
The guarded V2026071601 deployment stopped before ledger insertion with MySQL 1267 while comparing `messages.content` (`utf8mb4_unicode_ci`) with the generated schedule-card expression (`utf8mb4_bin`).

Safety checks after the stop:
- encrypted pre-migration backup committed
- V2026071601 is absent from `app_schema_migrations`
- the failed client connection rolled back the InnoDB transaction
- the stage-A backend remains healthy and the public API responds
- the frontend cutover remains unmerged

## Fix
- Applies `utf8mb4_unicode_ci` to the complete generated schedule-card expression for both assignment and null-safe comparison.
- Reproduces the production `messages.content` collation in MySQL integration tests.
- Seeds a stale deterministic card and verifies content repair, RSVP/read repair, one-card invariants, and retry safety across two migration runs.

## Local checks
- migration contract passed
- migration runner test passed
- `compileTestJava` passed
- `git diff --check` passed

GitHub Actions MySQL integration is the merge gate before retrying production deployment.