### PR TITLE
Let members recover a lost password

### DIFF
--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetChallenge.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetChallenge.java
@@ -1,0 +1,90 @@
+package com.talkwithneighbors.auth.password;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 진행 중인 비밀번호 재설정 요청.
+ *
+ * 코드는 원문이 아니라 해시로 저장한다. 데이터베이스를 읽을 수 있는 사람이
+ * 남의 비밀번호를 재설정할 수 있어서는 안 된다.
+ * 이메일당 한 건만 두어 요청이 쌓이지 않게 하고, 재요청은 같은 행을 갱신한다.
+ */
+@Entity
+@Table(name = "password_reset_challenges")
+@Getter
+@NoArgsConstructor
+public class PasswordResetChallenge {
+
+    @Id
+    @Column(name = "challenge_id", length = 36)
+    private String challengeId;
+
+    @Column(name = "email_normalized", nullable = false, unique = true, length = 320)
+    private String emailNormalized;
+
+    @Column(name = "code_hash", nullable = false, length = 64)
+    private String codeHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "resend_available_at", nullable = false)
+    private Instant resendAvailableAt;
+
+    @Column(name = "failed_attempts", nullable = false)
+    private int failedAttempts;
+
+    @Column(name = "consumed_at")
+    private Instant consumedAt;
+
+    @Version
+    private long version;
+
+    public static PasswordResetChallenge issue(
+            String emailNormalized, String codeHash, Instant now, PasswordResetProperties properties) {
+        PasswordResetChallenge challenge = new PasswordResetChallenge();
+        challenge.challengeId = UUID.randomUUID().toString();
+        challenge.emailNormalized = emailNormalized;
+        challenge.reissue(codeHash, now, properties);
+        return challenge;
+    }
+
+    /** 재요청. 이전 코드는 즉시 무효가 되고 시도 횟수와 소비 표시도 초기화된다. */
+    public void reissue(String codeHash, Instant now, PasswordResetProperties properties) {
+        this.codeHash = codeHash;
+        this.expiresAt = now.plus(properties.getCodeTtl());
+        this.resendAvailableAt = now.plus(properties.getResendCooldown());
+        this.failedAttempts = 0;
+        this.consumedAt = null;
+    }
+
+    public boolean canResend(Instant now) {
+        return !now.isBefore(resendAvailableAt);
+    }
+
+    public Duration retryAfter(Instant now) {
+        return canResend(now) ? Duration.ZERO : Duration.between(now, resendAvailableAt);
+    }
+
+    public boolean isUsable(Instant now, int maxAttempts) {
+        return consumedAt == null && now.isBefore(expiresAt) && failedAttempts < maxAttempts;
+    }
+
+    public void recordFailure() {
+        failedAttempts += 1;
+    }
+
+    public void consume(Instant now) {
+        this.consumedAt = now;
+    }
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetChallengeRepository.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetChallengeRepository.java
@@ -1,0 +1,14 @@
+package com.talkwithneighbors.auth.password;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface PasswordResetChallengeRepository extends JpaRepository<PasswordResetChallenge, String> {
+
+    Optional<PasswordResetChallenge> findByEmailNormalized(String emailNormalized);
+
+    /** 만료된 요청을 주기적으로 정리한다. */
+    void deleteByExpiresAtBefore(Instant cutoff);
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetController.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetController.java
@@ -1,0 +1,54 @@
+package com.talkwithneighbors.auth.password;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth/password-reset")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    public record ResetRequest(@NotBlank @Email @Size(max = 320) String email) {
+    }
+
+    public record ConfirmRequest(
+            @NotBlank @Email @Size(max = 320) String email,
+            @NotBlank @Size(min = 6, max = 6) String code,
+            @NotBlank @Size(min = 8, max = 100) String newPassword
+    ) {
+    }
+
+    /** 로그인 화면이 링크를 보여줄지 판단하는 데 쓴다. */
+    @GetMapping("/availability")
+    public ResponseEntity<Map<String, Boolean>> availability() {
+        return ResponseEntity.ok(Map.of("enabled", passwordResetService.isEnabled()));
+    }
+
+    /**
+     * 가입되지 않은 주소여도 202를 돌려준다. 계정 존재 여부를 알려 주지 않기 위해서다.
+     */
+    @PostMapping
+    public ResponseEntity<Void> request(@Valid @RequestBody ResetRequest request) {
+        passwordResetService.requestReset(request.email());
+        return ResponseEntity.accepted().build();
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<Void> confirm(@Valid @RequestBody ConfirmRequest request) {
+        passwordResetService.confirmReset(request.email(), request.code(), request.newPassword());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetEmailSender.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetEmailSender.java
@@ -1,0 +1,16 @@
+package com.talkwithneighbors.auth.password;
+
+import java.time.Duration;
+
+/**
+ * 재설정 코드를 실제로 보내는 수단.
+ *
+ * 구현을 갈아끼울 수 있게 분리했다. 현재 SES 구현이 있지만 발송 수단은 배포마다 다를 수 있고,
+ * 사용 가능한 구현이 없으면 기능 전체가 꺼진 상태로 동작한다.
+ */
+public interface PasswordResetEmailSender {
+
+    boolean isAvailable();
+
+    void sendResetCode(String email, String code, Duration validity);
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetProperties.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetProperties.java
@@ -1,0 +1,24 @@
+package com.talkwithneighbors.auth.password;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Getter
+@Setter
+@ConfigurationProperties("app.auth.password-reset")
+public class PasswordResetProperties {
+
+    /**
+     * 기능 자체의 켜짐 여부. 메일 발송 수단이 준비되지 않은 배포에서는 꺼 둔다.
+     */
+    private boolean enabled = false;
+
+    private Duration codeTtl = Duration.ofMinutes(10);
+
+    private Duration resendCooldown = Duration.ofMinutes(1);
+
+    private int maxAttempts = 5;
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/PasswordResetService.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/PasswordResetService.java
@@ -1,0 +1,176 @@
+package com.talkwithneighbors.auth.password;
+
+import com.talkwithneighbors.entity.User;
+import com.talkwithneighbors.exception.AuthException;
+import com.talkwithneighbors.repository.UserRepository;
+import com.talkwithneighbors.service.RedisSessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * 비밀번호 재설정.
+ *
+ * 전 과정에서 어떤 이메일이 가입되어 있는지 드러내지 않는다. 요청 응답은 계정이 있든 없든 같고,
+ * 확인 단계의 실패 사유도 구분하지 않는다. 로그인 폼이 막아 놓은 계정 열거를
+ * 재설정 폼이 대신 열어 주는 일이 흔하다.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@EnableConfigurationProperties(PasswordResetProperties.class)
+public class PasswordResetService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int MINIMUM_PASSWORD_LENGTH = 8;
+
+    private final PasswordResetProperties properties;
+    private final PasswordResetChallengeRepository challengeRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisSessionService redisSessionService;
+    private final ObjectProvider<PasswordResetEmailSender> emailSender;
+
+    public boolean isEnabled() {
+        PasswordResetEmailSender sender = emailSender.getIfAvailable();
+        return properties.isEnabled() && sender != null && sender.isAvailable();
+    }
+
+    /**
+     * 재설정 코드를 보낸다.
+     *
+     * 계정이 없거나 발송에 실패해도 호출자에게는 성공으로 보인다.
+     * 호출자가 구분할 수 있는 유일한 실패는 재발송 쿨다운이며, 이는 이미 요청을 보낸
+     * 본인만 마주치는 상태다.
+     */
+    @Transactional
+    public void requestReset(String email) {
+        if (!isEnabled()) {
+            throw new AuthException("비밀번호 재설정을 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        String normalized = normalize(email);
+        Instant now = Instant.now();
+
+        Optional<PasswordResetChallenge> existing = challengeRepository.findByEmailNormalized(normalized);
+        if (existing.isPresent() && !existing.get().canResend(now)) {
+            throw new AuthException(
+                    "잠시 후에 다시 요청해 주세요.",
+                    HttpStatus.TOO_MANY_REQUESTS);
+        }
+
+        Optional<User> user = userRepository.findByEmail(normalized);
+        if (user.isEmpty()) {
+            // 가입되지 않은 주소다. 응답은 성공과 동일하게 두어 계정 존재 여부를 감춘다.
+            return;
+        }
+
+        String code = generateCode();
+        PasswordResetChallenge challenge = existing
+                .map(found -> {
+                    found.reissue(hash(code), now, properties);
+                    return found;
+                })
+                .orElseGet(() -> PasswordResetChallenge.issue(normalized, hash(code), now, properties));
+        challengeRepository.save(challenge);
+
+        try {
+            emailSender.getObject().sendResetCode(normalized, code, properties.getCodeTtl());
+        } catch (RuntimeException exception) {
+            // 발송 실패를 알리면 어떤 주소가 존재하는지 유추할 수 있다. 기록만 남긴다.
+            log.warn("Password reset delivery failed", exception);
+        }
+    }
+
+    /**
+     * 코드를 확인하고 비밀번호를 바꾼다.
+     *
+     * 성공하면 그 계정의 모든 세션을 끊는다. 재설정을 요청하는 흔한 이유가
+     * 계정을 도난당했기 때문인데, 세션을 남겨 두면 침입자가 그대로 남는다.
+     */
+    @Transactional
+    public void confirmReset(String email, String code, String newPassword) {
+        if (!isEnabled()) {
+            throw new AuthException("비밀번호 재설정을 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+        }
+        if (newPassword == null || newPassword.length() < MINIMUM_PASSWORD_LENGTH) {
+            throw new AuthException(
+                    "비밀번호는 " + MINIMUM_PASSWORD_LENGTH + "자 이상이어야 합니다.",
+                    HttpStatus.BAD_REQUEST);
+        }
+
+        String normalized = normalize(email);
+        Instant now = Instant.now();
+
+        PasswordResetChallenge challenge = challengeRepository.findByEmailNormalized(normalized)
+                .orElseThrow(this::invalidCode);
+
+        if (!challenge.isUsable(now, properties.getMaxAttempts())) {
+            throw invalidCode();
+        }
+
+        if (!constantTimeEquals(challenge.getCodeHash(), hash(code == null ? "" : code))) {
+            challenge.recordFailure();
+            challengeRepository.save(challenge);
+            throw invalidCode();
+        }
+
+        User user = userRepository.findByEmail(normalized).orElseThrow(this::invalidCode);
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        challenge.consume(now);
+        challengeRepository.save(challenge);
+
+        redisSessionService.removeUserSessions(String.valueOf(user.getId()));
+    }
+
+    /**
+     * 코드가 틀렸는지, 만료되었는지, 애초에 요청이 없었는지를 구분해 주지 않는다.
+     * 구분해 주면 그 자체가 계정 존재 여부를 알려 주는 신호가 된다.
+     */
+    private AuthException invalidCode() {
+        return new AuthException("인증번호가 올바르지 않거나 만료되었습니다.", HttpStatus.BAD_REQUEST);
+    }
+
+    private String normalize(String email) {
+        if (email == null || email.isBlank()) {
+            throw new AuthException("이메일을 입력해 주세요.", HttpStatus.BAD_REQUEST);
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /** 앞자리가 0이어도 여섯 자리를 유지하도록 문자열로 만든다. */
+    private String generateCode() {
+        return String.format("%06d", RANDOM.nextInt(1_000_000));
+    }
+
+    private String hash(String code) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(code.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new IllegalStateException("SHA-256 is required to hash reset codes", exception);
+        }
+    }
+
+    /** 해시 비교 시간이 코드 내용에 따라 달라지지 않게 한다. */
+    private boolean constantTimeEquals(String left, String right) {
+        return MessageDigest.isEqual(
+                left.getBytes(StandardCharsets.UTF_8),
+                right.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/talkwithneighbors/auth/password/SesPasswordResetEmailSender.java
+++ b/src/main/java/com/talkwithneighbors/auth/password/SesPasswordResetEmailSender.java
@@ -1,0 +1,53 @@
+package com.talkwithneighbors.auth.password;
+
+import com.talkwithneighbors.auth.email.EmailVerificationProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+
+import java.time.Duration;
+
+/**
+ * 이메일 인증과 같은 SES 설정을 재사용한다. 발신 주소와 리전을 두 벌로 관리할 이유가 없다.
+ */
+@Component
+@ConditionalOnProperty(name = "app.auth.email.sender", havingValue = "ses")
+public class SesPasswordResetEmailSender implements PasswordResetEmailSender {
+
+    private final SesV2Client client;
+    private final EmailVerificationProperties properties;
+
+    public SesPasswordResetEmailSender(SesV2Client client, EmailVerificationProperties properties) {
+        this.client = client;
+        this.properties = properties;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return properties.getFrom() != null && !properties.getFrom().isBlank();
+    }
+
+    @Override
+    public void sendResetCode(String email, String code, Duration validity) {
+        String text = "이웃톡 비밀번호 재설정 인증번호는 " + code + " 입니다. "
+                + validity.toMinutes() + "분 안에 입력해 주세요. "
+                + "본인이 요청하지 않았다면 이 메일을 무시해 주세요.";
+
+        Message message = Message.builder()
+                .subject(Content.builder().data("이웃톡 비밀번호 재설정").charset("UTF-8").build())
+                .body(Body.builder().text(Content.builder().data(text).charset("UTF-8").build()).build())
+                .build();
+
+        client.sendEmail(SendEmailRequest.builder()
+                .fromEmailAddress(properties.getFrom())
+                .destination(Destination.builder().toAddresses(email).build())
+                .content(EmailContent.builder().simple(message).build())
+                .build());
+    }
+}

--- a/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
+++ b/src/main/java/com/talkwithneighbors/config/SecurityConfig.java
@@ -56,8 +56,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(HttpMethod.POST,
                         "/api/auth/login", "/api/auth/register", "/api/auth/logout",
-                        "/api/auth/email-verifications", "/api/auth/email-verifications/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/auth/check-duplicates").permitAll()
+                        "/api/auth/email-verifications", "/api/auth/email-verifications/**",
+                        "/api/auth/password-reset", "/api/auth/password-reset/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/auth/check-duplicates",
+                        "/api/auth/password-reset/availability").permitAll()
                 .requestMatchers("/api/public/**").permitAll()
                 .requestMatchers("/api/oauth2/authorization/**", "/api/login/oauth2/code/**").permitAll()
                 .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -154,6 +154,12 @@ app:
       proof-cookie-secure: ${APP_AUTH_EMAIL_PROOF_COOKIE_SECURE:true}
       request-limit-per-window: ${APP_AUTH_EMAIL_REQUEST_LIMIT:5}
       request-window: ${APP_AUTH_EMAIL_REQUEST_WINDOW:PT10M}
+    password-reset:
+      # 메일 발송 수단이 준비된 배포에서만 켠다. 꺼져 있으면 로그인 화면에 링크도 뜨지 않는다.
+      enabled: ${APP_AUTH_PASSWORD_RESET_ENABLED:false}
+      code-ttl: ${APP_AUTH_PASSWORD_RESET_CODE_TTL:PT10M}
+      resend-cooldown: ${APP_AUTH_PASSWORD_RESET_RESEND_COOLDOWN:PT1M}
+      max-attempts: ${APP_AUTH_PASSWORD_RESET_MAX_ATTEMPTS:5}
   push:
     # VAPID 키가 모두 설정되어야 실제로 발송한다. 키가 없으면 구독 UI도 나타나지 않는다.
     enabled: ${APP_PUSH_ENABLED:false}

--- a/src/test/java/com/talkwithneighbors/auth/password/PasswordResetServiceTest.java
+++ b/src/test/java/com/talkwithneighbors/auth/password/PasswordResetServiceTest.java
@@ -1,0 +1,182 @@
+package com.talkwithneighbors.auth.password;
+
+import com.talkwithneighbors.entity.User;
+import com.talkwithneighbors.exception.AuthException;
+import com.talkwithneighbors.repository.UserRepository;
+import com.talkwithneighbors.service.RedisSessionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PasswordResetServiceTest {
+
+    @Mock PasswordResetChallengeRepository challengeRepository;
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock RedisSessionService redisSessionService;
+
+    PasswordResetProperties properties;
+    PasswordResetEmailSender sender;
+    PasswordResetService service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        properties = new PasswordResetProperties();
+        properties.setEnabled(true);
+
+        sender = mock(PasswordResetEmailSender.class);
+        when(sender.isAvailable()).thenReturn(true);
+
+        ObjectProvider<PasswordResetEmailSender> provider = mock(ObjectProvider.class, RETURNS_DEEP_STUBS);
+        when(provider.getIfAvailable()).thenReturn(sender);
+        when(provider.getObject()).thenReturn(sender);
+
+        service = new PasswordResetService(
+                properties, challengeRepository, userRepository, passwordEncoder, redisSessionService, provider);
+    }
+
+    private User member(String email) {
+        return User.builder().id(5L).email(email).username("member").password("old-hash")
+                .latitude(0.0).longitude(0.0).address("a").build();
+    }
+
+    @Test
+    void featureIsOffWhenNoSenderIsConfigured() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<PasswordResetEmailSender> empty = mock(ObjectProvider.class);
+        when(empty.getIfAvailable()).thenReturn(null);
+        PasswordResetService offline = new PasswordResetService(
+                properties, challengeRepository, userRepository, passwordEncoder, redisSessionService, empty);
+
+        assertThat(offline.isEnabled()).isFalse();
+        assertThatThrownBy(() -> offline.requestReset("someone@example.test"))
+                .isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    void unknownAddressLooksExactlyLikeASuccessfulRequest() {
+        when(challengeRepository.findByEmailNormalized("ghost@example.test")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail("ghost@example.test")).thenReturn(Optional.empty());
+
+        service.requestReset("Ghost@Example.Test");
+
+        // 없는 계정에는 코드를 만들지도, 메일을 보내지도 않는다. 그러나 예외도 던지지 않는다.
+        verify(challengeRepository, never()).save(any());
+        verify(sender, never()).sendResetCode(anyString(), anyString(), any());
+    }
+
+    @Test
+    void knownAddressStoresOnlyAHashAndMailsTheCode() {
+        when(challengeRepository.findByEmailNormalized("member@example.test")).thenReturn(Optional.empty());
+        when(userRepository.findByEmail("member@example.test"))
+                .thenReturn(Optional.of(member("member@example.test")));
+
+        service.requestReset("member@example.test");
+
+        ArgumentCaptor<PasswordResetChallenge> saved = ArgumentCaptor.forClass(PasswordResetChallenge.class);
+        verify(challengeRepository).save(saved.capture());
+
+        ArgumentCaptor<String> mailedCode = ArgumentCaptor.forClass(String.class);
+        verify(sender).sendResetCode(any(), mailedCode.capture(), any(Duration.class));
+
+        assertThat(mailedCode.getValue()).hasSize(6).containsOnlyDigits();
+        assertThat(saved.getValue().getCodeHash())
+                .hasSize(64)
+                .isNotEqualTo(mailedCode.getValue());
+    }
+
+    @Test
+    void deliveryFailureIsSwallowedSoItCannotRevealWhoIsRegistered() {
+        when(challengeRepository.findByEmailNormalized(anyString())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(member("member@example.test")));
+        doThrow(new RuntimeException("SES rejected")).when(sender)
+                .sendResetCode(anyString(), anyString(), any());
+
+        service.requestReset("member@example.test");
+    }
+
+    @Test
+    void resendIsRefusedDuringTheCooldown() {
+        PasswordResetChallenge fresh = PasswordResetChallenge.issue(
+                "member@example.test", "hash", java.time.Instant.now(), properties);
+        when(challengeRepository.findByEmailNormalized("member@example.test")).thenReturn(Optional.of(fresh));
+
+        assertThatThrownBy(() -> service.requestReset("member@example.test"))
+                .isInstanceOf(AuthException.class)
+                .satisfies(thrown -> assertThat(((AuthException) thrown).getStatus())
+                        .isEqualTo(HttpStatus.TOO_MANY_REQUESTS));
+    }
+
+    @Test
+    void shortPasswordIsRejectedBeforeAnyCodeIsChecked() {
+        assertThatThrownBy(() -> service.confirmReset("member@example.test", "123456", "short"))
+                .isInstanceOf(AuthException.class);
+
+        verify(challengeRepository, never()).findByEmailNormalized(anyString());
+    }
+
+    @Test
+    void wrongCodeCountsAsAFailedAttemptAndKeepsTheReasonVague() {
+        PasswordResetChallenge challenge = PasswordResetChallenge.issue(
+                "member@example.test", "a".repeat(64), java.time.Instant.now(), properties);
+        when(challengeRepository.findByEmailNormalized("member@example.test"))
+                .thenReturn(Optional.of(challenge));
+
+        assertThatThrownBy(() -> service.confirmReset("member@example.test", "000000", "long-enough-password"))
+                .isInstanceOf(AuthException.class)
+                .hasMessageContaining("인증번호가 올바르지 않거나 만료되었습니다");
+
+        assertThat(challenge.getFailedAttempts()).isEqualTo(1);
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void missingChallengeFailsTheSameWayAsAWrongCode() {
+        when(challengeRepository.findByEmailNormalized("ghost@example.test")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.confirmReset("ghost@example.test", "000000", "long-enough-password"))
+                .isInstanceOf(AuthException.class)
+                .hasMessageContaining("인증번호가 올바르지 않거나 만료되었습니다");
+    }
+
+    @Test
+    void challengeStopsWorkingOnceAttemptsRunOut() {
+        PasswordResetChallenge challenge = PasswordResetChallenge.issue(
+                "member@example.test", "hash", java.time.Instant.now(), properties);
+        for (int attempt = 0; attempt < properties.getMaxAttempts(); attempt += 1) {
+            challenge.recordFailure();
+        }
+
+        assertThat(challenge.isUsable(java.time.Instant.now(), properties.getMaxAttempts())).isFalse();
+    }
+
+    @Test
+    void consumedChallengeCannotBeReused() {
+        PasswordResetChallenge challenge = PasswordResetChallenge.issue(
+                "member@example.test", "hash", java.time.Instant.now(), properties);
+        challenge.consume(java.time.Instant.now());
+
+        assertThat(challenge.isUsable(java.time.Instant.now(), properties.getMaxAttempts())).isFalse();
+    }
+}


### PR DESCRIPTION
## 문제

**비밀번호를 잊으면 계정으로 돌아올 방법이 없었습니다.** 재설정 흐름이 아예 없어서, 소셜 계정을 연결해 두지 않은 사용자는 계정을 영구히 잃습니다.

## 흐름

이메일로 6자리 코드를 보내고 확인합니다. 재설정 **링크** 대신 코드를 쓴 이유는 기존 이메일 인증과 설계를 맞추기 위해서입니다.

| 메서드 | 경로 | 기능 |
| --- | --- | --- |
| GET | `/api/auth/password-reset/availability` | 기능 사용 가능 여부 |
| POST | `/api/auth/password-reset` | 코드 발송 요청 |
| POST | `/api/auth/password-reset/confirm` | 코드 확인 후 변경 |

코드는 **SHA-256 해시로 저장**하고, 10분 만료, 5회 시도 제한, 1회용입니다. 재발송 쿨다운으로 이 엔드포인트가 메일 발송기로 쓰이는 것을 막습니다.

## 계정 존재 여부를 절대 노출하지 않습니다

로그인 폼이 조심스럽게 감추는 계정 열거를 재설정 폼이 대신 열어 주는 일이 흔합니다.

- 가입되지 않은 주소로 요청해도 **가입된 주소와 똑같은 202**를 돌려주고 아무것도 저장하지 않습니다.
- **발송 실패는 로그만 남깁니다.** 실제 주소에서만 오류가 나면 그 자체가 답이 됩니다.
- 확인 실패 시 **코드가 틀렸는지, 만료됐는지, 시도를 소진했는지, 애초에 요청이 없었는지 구분해 주지 않습니다.**

해시 비교는 `MessageDigest.isEqual`로 상수 시간에 합니다.

## 재설정 후 전체 세션 종료

성공하면 해당 사용자의 **모든 세션을 끊습니다**. 비밀번호를 재설정하는 흔한 이유가 계정을 도난당했다고 판단해서인데, 세션을 남겨 두면 침입자가 그대로 남아 있게 됩니다.

## 발송 수단은 갈아끼울 수 있습니다

`PasswordResetEmailSender` 인터페이스 뒤에 두었습니다. SES 구현을 포함했고 이메일 인증의 발신 주소·리전 설정을 재사용합니다.

**SES 샌드박스 해제가 거부된 상태**라는 점을 감안해, sender 빈이 없거나 설정되지 않으면 기능이 스스로 "사용 불가"를 보고하고 클라이언트는 진입점을 감춥니다. 다른 발송 수단이 정해지면 인터페이스 구현체만 추가하면 됩니다.

배포 시 `APP_AUTH_PASSWORD_RESET_ENABLED`가 필요하며 **기본값은 꺼짐**입니다. 머지해도 동작이 바뀌지 않습니다.

## 검증

- 백엔드 테스트 전체 통과 (`BUILD SUCCESSFUL`)
- 신규 테스트 10건
  - sender 없으면 비활성, **없는 주소도 성공과 동일하게 동작**, 해시만 저장하고 원문 코드는 메일로만, **발송 실패를 삼킴**, 쿨다운 중 429, 짧은 비밀번호는 코드 검사 전에 거부, 틀린 코드는 시도 횟수 증가 + 모호한 메시지, **요청 없는 확인도 같은 메시지**, 시도 소진 시 사용 불가, 소비된 코드 재사용 불가

프런트엔드는 같은 이름의 브랜치입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)